### PR TITLE
Fix work samples grid wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,12 +120,13 @@
         </div>
     </section>
 
-<!-- Work Samples Section -->
+        <!-- Work Samples Section -->
 <section id="work-samples" class="work-samples-section" role="region" aria-labelledby="work-samples-heading">
     <h2 id="work-samples-heading" class="section-title" data-aos="fade-up">WORK SAMPLES</h2>
     <p class="sub-heading" data-aos="fade-up" data-aos-delay="200">*more samples available upon request</p>
+    <div class="work-samples-grid">
 
-<!-- Work Sample 1 -->
+        <!-- Work Sample 1 -->
         <div class="work-sample" data-aos="zoom-in">
             <div class="video-wrapper">
                 <iframe 


### PR DESCRIPTION
## Summary
- wrap the work sample videos in `.work-samples-grid`
- indent work sample comments for clarity

## Testing
- `npm test` *(fails: package.json missing)*
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68473067905483289c8b4729f4b8d41d