### PR TITLE
Add HTML lint test with HTMLHint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ https://www.linkedin.com/in/mikekuell/  +
 https://vimeo.com/jetpak  +
 https://www.instagram.com/michael_kuell/  +
 
+
+## Testing
+
+Run `npm test` to lint `index.html` using HTMLHint.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/validate-html.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "htmlhint": "^0.16.2"
+  }
+}

--- a/test/validate-html.js
+++ b/test/validate-html.js
@@ -1,0 +1,15 @@
+const { HTMLHint } = require('htmlhint');
+const fs = require('fs');
+
+const html = fs.readFileSync('index.html', 'utf8');
+const messages = HTMLHint.verify(html, {});
+
+if (messages.length > 0) {
+  console.error('HTMLHint errors found:');
+  messages.forEach(msg => {
+    console.error(`${msg.line}:${msg.col} ${msg.message} (${msg.rule.id})`);
+  });
+  process.exit(1);
+} else {
+  console.log('HTML looks good.');
+}


### PR DESCRIPTION
## Summary
- set up `package.json` with HTMLHint as a dev dependency
- add a script to validate `index.html`
- document running `npm test` in README

## Testing
- `npm test` *(fails: `npm` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847307e0a788328905561fc062673af