### PR TITLE
Add scroll-spy to highlight active navigation link

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,3 +85,24 @@ document.querySelectorAll('.bio-toggle').forEach(btn => {
         btn.textContent = expanded ? 'Show Less' : 'Read More';
     });
 });
+
+// Scroll-spy using Intersection Observer
+if (navLinks.length > 0) {
+    const sections = Array.from(navLinks)
+        .map(link => document.querySelector(link.hash))
+        .filter(Boolean);
+
+    const observerOptions = { threshold: 0.6 };
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const id = entry.target.id;
+                navLinks.forEach(link => {
+                    link.classList.toggle('active', link.hash === `#${id}`);
+                });
+            }
+        });
+    }, observerOptions);
+
+    sections.forEach(section => observer.observe(section));
+}

--- a/styles.css
+++ b/styles.css
@@ -138,6 +138,12 @@ p {
     transition: color var(--transition-duration) ease;
 }
 
+/* Active navigation link */
+.nav-list a.active {
+    color: var(--color-accent);
+    font-weight: bold;
+}
+
 .nav-toggle {
     display: none;
     background: none;


### PR DESCRIPTION
## Summary
- highlight active menu items on scroll
- implement IntersectionObserver scroll-spy in `script.js`
- style `.nav-list a.active` in `styles.css`

## Testing
- `npm test` *(fails: Cannot find module 'htmlhint')*

------
https://chatgpt.com/codex/tasks/task_e_684735a903448328a3dc3973e02d32b8