### PR TITLE
Add base style for data-aos visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,11 @@ p {
     color: var(--color-text);
 }
 
+[data-aos] {
+    opacity: 1;
+    transform: none;
+}
+
 /* ===== Site Header ===== */
 .site-header {
     /* Sticky navigation that remains visible as the page scrolls */


### PR DESCRIPTION
## Summary
- ensure that elements using `data-aos` remain visible when AOS JavaScript doesn't run

## Testing
- `npm test` *(fails: Cannot find module 'htmlhint')*

------
https://chatgpt.com/codex/tasks/task_e_68473b10605483288fcd5200fe7fafc0