### PR TITLE
Fix blue overlay contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -528,7 +528,8 @@ p {
 
 .contact-text-box {
     position: relative;
-    background-color: rgba(100, 100, 150, 0.5);
+    /* Deeper blue for better contrast on light and dark backgrounds */
+    background-color: rgba(50, 75, 150, 0.8);
     padding: 1rem;
     border-radius: 12px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- use darker overlay blue for the contact section

## Testing
- `npm test` *(fails: HTMLHint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68473ee101588328a98b9e575a065ac8