### PR TITLE
Fix AOS script source

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
 <!-- External JavaScript -->
 <script src="script.js"></script>
 <!-- AOS JS -->
-<script src="assets/vendor/aos/aos.js"></script>
+<script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
 <script>
     // Initialize AOS (Animation on Scroll)
     AOS.init({


### PR DESCRIPTION
## Summary
- load AOS from CDN instead of local vendor file

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68482edbd5b88328be33f7b0d8d22e9d