### PR TITLE
Add lightbox modal for videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,15 @@
     </div>
 </section>
 
+<!-- Video Modal -->
+<div id="video-modal" class="modal" hidden>
+  <div class="modal-backdrop"></div>
+  <div class="modal-content" role="dialog" aria-modal="true">
+    <button class="modal-close" aria-label="Close video">✖</button>
+    <div class="modal-video-container"></div>
+  </div>
+</div>
+
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
     <p>&copy; <span id="current-year"></span> Michael Kuell</p>

--- a/script.js
+++ b/script.js
@@ -141,18 +141,34 @@ function initVideoPlaceholders() {
 
         button.addEventListener('click', e => {
             e.preventDefault();
-            const src = `${wrapper.dataset.src}?autoplay=1`;
-            const title = wrapper.dataset.title || 'video player';
-            const iframe = document.createElement('iframe');
-            iframe.src = src;
-            iframe.title = title;
-            iframe.setAttribute('aria-label', title);
-            iframe.setAttribute('allow', 'autoplay; fullscreen; picture-in-picture');
-            iframe.setAttribute('allowfullscreen', '');
-            iframe.setAttribute('loading', 'lazy');
-            iframe.frameBorder = '0';
-            wrapper.innerHTML = '';
-            wrapper.appendChild(iframe);
+            openModal(wrapper);
         });
     });
 }
+
+function openModal(wrapper) {
+    const modal = document.getElementById('video-modal');
+    const container = modal.querySelector('.modal-video-container');
+    const src = `${wrapper.dataset.src}?autoplay=1`;
+    const ratio = wrapper.style.getPropertyValue('--ratio') || '16/9';
+
+    container.style.setProperty('--modal-ratio', ratio);
+    container.innerHTML = `<iframe src="${src}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>`;
+
+    modal.hidden = false;
+    document.body.style.overflow = 'hidden';
+    container.querySelector('iframe').focus();
+}
+
+function closeModal() {
+    const modal = document.getElementById('video-modal');
+    modal.hidden = true;
+    modal.querySelector('.modal-video-container').innerHTML = '';
+    document.body.style.overflow = '';
+}
+
+document.querySelector('#video-modal .modal-close').addEventListener('click', closeModal);
+document.querySelector('#video-modal .modal-backdrop').addEventListener('click', closeModal);
+document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') closeModal();
+});

--- a/styles.css
+++ b/styles.css
@@ -302,6 +302,48 @@ p {
     outline: 2px solid #fff;
 }
 
+/* Lightbox Modal */
+.modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 1000;
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal-content {
+    position: relative;
+    max-width: 90%;
+    max-height: 90%;
+}
+
+.modal-video-container {
+    width: 100%;
+    height: 100%;
+    aspect-ratio: var(--modal-ratio, 16/9);
+}
+
+.modal-video-container iframe {
+    width: 100%;
+    height: 100%;
+}
+
+.modal-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
 /* Responsive Adjustments for Work Samples */
 @media (max-width: 768px) {
     .work-samples-grid {


### PR DESCRIPTION
## Summary
- add markup for video modal lightbox
- style modal overlay and container
- update JavaScript to open videos in modal instead of replacing thumbnail

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848701b4a288328afa2bd3d77e46ca2