### PR TITLE
Fix theme variables and header dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,10 +11,10 @@
 
     /* Colors */
     --color-background-dark: #3b3b3b;
-    --color-background-light: ##fcfcfc;
+    --color-background-light: #fcfcfc;
     --color-text-dark: #edf0f2;
     --color-text-light: #333333;
-    --color-accent: #545454;
+    --color-accent: #0077b6;
     --color-muted: #9a9a9a;
 
     /* Transition & Layout */
@@ -113,7 +113,7 @@ p {
 }
 
 .site-header.scrolled {
-    background-color: #fff;
+    background-color: var(--color-background);
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 


### PR DESCRIPTION
## Summary
- fix the light mode background variable and switch accent color to a vivid teal
- make the scrolled header respect the active theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848af7467688328b462859f0595f42f