### PR TITLE
Add hover video titles

### DIFF
--- a/script.js
+++ b/script.js
@@ -127,6 +127,14 @@ function initVideoPlaceholders() {
         const button = wrapper.querySelector('.play-button');
         if (!img || !button) return;
 
+        const titleText = wrapper.dataset.title;
+        if (titleText) {
+            const titleDiv = document.createElement('div');
+            titleDiv.className = 'video-title';
+            titleDiv.textContent = titleText;
+            wrapper.appendChild(titleDiv);
+        }
+
         const setRatio = () => {
             const ratio = img.naturalWidth / img.naturalHeight;
             if (ratio) {

--- a/styles.css
+++ b/styles.css
@@ -302,6 +302,28 @@ p {
     outline: 2px solid #fff;
 }
 
+/* Video title overlay */
+.video-title {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    padding: 0.5rem;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    font-size: 0.9rem;
+    text-align: center;
+    opacity: 0;
+    transform: translateY(100%);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+}
+
+.video-wrapper:hover .video-title {
+    opacity: 1;
+    transform: translateY(0);
+}
+
 /* Lightbox Modal */
 .modal {
     position: fixed;


### PR DESCRIPTION
## Summary
- display custom video titles on video placeholders
- style `.video-title` overlay to fade and slide up on hover

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c4735a88832897a7c94d12184395