### PR TITLE
Add divider graphics between sections

### DIFF
--- a/assets/images/divider-diagonal.svg
+++ b/assets/images/divider-diagonal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 100" preserveAspectRatio="none">
+  <polygon points="0,0 1200,0 0,100" fill="currentColor"/>
+</svg>

--- a/assets/images/divider-wave.svg
+++ b/assets/images/divider-wave.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 100" preserveAspectRatio="none">
+  <path d="M0,0 V40 Q300,80 600,40 T1200,40 V0z" fill="currentColor"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -198,6 +198,10 @@
         </div>
     </div>
 </section>
+    <!-- Divider: Work Samples to Testimonials -->
+    <div class="section-divider divider-wave" aria-hidden="true">
+        <img src="assets/images/divider-wave.svg" alt="" class="divider-img">
+    </div>
 
 <!-- Testimonials Section -->
 <section id="testimonials" class="testimonials-section" role="region" aria-labelledby="testimonials-heading">
@@ -255,7 +259,11 @@
         </div>
     </div>
 </section>
-    
+    <!-- Divider: Testimonials to Bio -->
+    <div class="section-divider divider-diagonal" aria-hidden="true">
+        <img src="assets/images/divider-diagonal.svg" alt="" class="divider-img">
+    </div>
+
  <!-- Bio Section -->
 <section id="bio" class="bio-section" role="region" aria-labelledby="bio-heading">
     <div class="bio-container">

--- a/styles.css
+++ b/styles.css
@@ -802,3 +802,26 @@ p {
         grid-template-columns: 1fr;
     }
 }
+
+/* ===== Section Dividers ===== */
+.section-divider {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    line-height: 0;
+}
+
+.section-divider svg,
+.section-divider img {
+    display: block;
+    width: 100%;
+    height: 80px;
+}
+
+.divider-wave {
+    color: var(--color-background);
+}
+
+.divider-diagonal {
+    color: var(--color-accent);
+}


### PR DESCRIPTION
## Summary
- add SVG divider images
- insert dividers between Work Samples, Testimonials, and Bio sections
- style divider elements in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d8d940e08328b7e7fa3c42466e44