### PR TITLE
Add hero video overlay with tagline and CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,12 +112,9 @@
         </video>
 
         <!-- Overlay Content -->
-        <div class="overlay">
-            <h1 id="cover-title" class="main-title" data-aos="fade-up">Michael Kuell</h1>
-            <h2 class="sub-title" data-aos="fade-up" data-aos-delay="200">
-                Creative Producer | Video Director | Storyteller
-            </h2>
-            <p class="cta-text" data-aos="fade-up" data-aos-delay="400">MY STORY // PORTFOLIO</p>
+        <div class="overlay hero-panel">
+            <h1 class="tagline">Video that Connects | Michael Kuell</h1>
+            <a href="#work-samples" class="cta-button">See My Reel</a>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -5,6 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add 'loaded' class so the CSS fade-in effect can start
     document.body.classList.add('loaded');
 
+    const heroOverlay = document.querySelector('.overlay');
+    if (heroOverlay) {
+        heroOverlay.classList.add('show');
+    }
+
     // Dynamic Year in Footer
     const yearSpan = document.getElementById('current-year');
     if (yearSpan) {

--- a/styles.css
+++ b/styles.css
@@ -427,8 +427,38 @@ p {
 }
 
 .overlay {
-    padding: 0 2rem;
+    padding: 2rem;
+    max-width: 80%;
+    margin: 0 auto;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
     z-index: 2;
+    opacity: 0;
+}
+
+.overlay.show {
+    animation: fadeInOverlay 1.5s ease forwards;
+}
+
+.tagline {
+    color: var(--color-text-dark);
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+}
+
+.cta-button {
+    display: inline-block;
+    background-color: var(--color-accent);
+    color: var(--color-text-dark);
+    padding: 0.5rem 1.5rem;
+    border-radius: 4px;
+    text-decoration: none;
+    transition: background-color var(--transition-duration) ease;
+}
+
+.cta-button:hover,
+.cta-button:focus {
+    background-color: #005f92;
 }
 
 .main-title, .sub-title, .cta-text {


### PR DESCRIPTION
## Summary
- overlay hero video with a semi-transparent panel
- add tagline and CTA button linking to work samples
- style overlay and CTA button using accent color
- fade in overlay on page load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68713b7ec3008328b765beee2d894e5e