### PR TITLE
Add testimonial excerpt carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,10 +212,11 @@
             <img src="assets/images/JBromberg.jpeg"
                  alt="Portrait of Jonas Bromberg, Psy.D, Principal Consultant at Crossroads Health"
                  class="testimonial-image" loading="lazy">
-            <blockquote>
+            <p class="testimonial-author"><strong>- Jonas Bromberg, Psy.D.</strong><br>Principal Consultant @ Crossroads Health</p>
+            <p class="testimonial-excerpt">I have worked with Michael and his team on several occasions, and from start to finish, the experience was always fantastic. <button class="testimonial-toggle" aria-expanded="false" aria-controls="testimonial-1">Read More</button></p>
+            <blockquote id="testimonial-1" class="testimonial-full" hidden tabindex="-1">
                 <p>"I have worked with Michael and his team on several occasions, and from start to finish, the experience was always fantastic. Great creative thinking, detailed preparation, and highly professional execution, made this part of my projects run like clockwork. Michael and his team define 'service oriented' and the results have always been outstanding."</p>
             </blockquote>
-            <p class="testimonial-author"><strong>- Jonas Bromberg, Psy.D.</strong><br>Principal Consultant @ Crossroads Health</p>
             </div>
         </div>
             <!-- Testimonial 2 -->
@@ -224,10 +225,11 @@
             <img src="assets/images/sonja_p.jpeg"
                  alt="Portrait of Sonya Ponder, DEI Talent Acquisition Manager at Princeton University"
                  class="testimonial-image" loading="lazy">
-            <blockquote>
+            <p class="testimonial-author"><strong>- Sonya Ponder</strong><br>Diversity, Equity and Inclusion Talent Acquisition Manager at Princeton University</p>
+            <p class="testimonial-excerpt">I had the pleasure of being in several projects produced by Michael in my last role. <button class="testimonial-toggle" aria-expanded="false" aria-controls="testimonial-2">Read More</button></p>
+            <blockquote id="testimonial-2" class="testimonial-full" hidden tabindex="-1">
             <p>"I had the pleasure of being in several projects produced by Michael in my last role. Being in front of the camera can be very intimidating, especially when having little experience, but Michael always made the process easy to understand and fun. He is professional, approachable, and down to earth in a way that made anyone working with him want to be their best. From that perspective, I would highly recommend Michael in any client/customer facing roles."</p>
             </blockquote>
-            <p class="testimonial-author"><strong>- Sonya Ponder</strong><br>Diversity, Equity and Inclusion Talent Acquisition Manager at Princeton University</p>
             </div>
         </div>
             <!-- Testimonial 3 -->
@@ -236,10 +238,11 @@
             <img src="assets/images/DaveGreeley.jpeg"
                  alt="Portrait of Dave Greeley, Partner at McKenna and Partners"
                  class="testimonial-image" loading="lazy">
-            <blockquote>
+            <p class="testimonial-author"><strong>- Dave Greeley</strong><br>Partner @ McKenna and Partners</p>
+            <p class="testimonial-excerpt">The last time I worked with Mike, we were under every kind of pressure possible: political, financial, creative, temporal and trying to shoot in English and French simultaneously. <button class="testimonial-toggle" aria-expanded="false" aria-controls="testimonial-3">Read More</button></p>
+            <blockquote id="testimonial-3" class="testimonial-full" hidden tabindex="-1">
             <p>"The last time I worked with Mike, we were under every kind of pressure possible: political, financial, creative, temporal and trying to shoot in English and French simultaneously. We wrapped half an hour early. I recommend Mike without reservation. As a director, cinematographer, collaborator and leader, he’s nigh on peerless. You might think trusting an airline pilot is a big deal, but for people in my business, choosing a director is much, much hairier. As far as I’m concerned, it’s Mike Kuell or we find a way to do it in print."</p>
             </blockquote>
-            <p class="testimonial-author"><strong>- Dave Greeley</strong><br>Partner @ McKenna and Partners</p>
             </div>
         </div>
             <!-- Testimonial 4 -->
@@ -248,10 +251,11 @@
             <img src="assets/images/CCarr.jpeg"
                  alt="Portrait of Cathleen Carr, Creative Social Impact Leader"
                  class="testimonial-image" loading="lazy">
-            <blockquote>
+            <p class="testimonial-author"><strong>- Cathleen Carr</strong><br>Creative Social Impact Leader</p>
+            <p class="testimonial-excerpt">Michael is an exceptional Executive Producer, Director and Filmmaker. <button class="testimonial-toggle" aria-expanded="false" aria-controls="testimonial-4">Read More</button></p>
+            <blockquote id="testimonial-4" class="testimonial-full" hidden tabindex="-1">
             <p>"Michael is an exceptional Executive Producer, Director and Filmmaker. His level of professionalism and focus is remarkable. As a mentor, Michael has helped me redirect my skill set towards all aspects of video production. His innate ability to communicate effectively is one of his many great strengths. During a rigorous shoot that spanned 5 cities, I was privileged to witness Michael conduct over 40 interviews with some of the nation's top psychologists."</p>
             </blockquote>
-            <p class="testimonial-author"><strong>- Cathleen Carr</strong><br>Creative Social Impact Leader</p>
             </div>
         </div>
             <!-- Testimonial 5 -->
@@ -260,10 +264,11 @@
             <img src="assets/images/JRose_pic.jpeg"
                  alt="Portrait of Jay Rose, Sound Designer"
                  class="testimonial-image" loading="lazy">
-            <blockquote>
+            <p class="testimonial-author"><strong>- Jay Rose, </strong><br>Sound Designer, Digital Playroom</p>
+            <p class="testimonial-excerpt">Mike is one of the most versatile, professional, and driven filmmakers I've ever worked with. <button class="testimonial-toggle" aria-expanded="false" aria-controls="testimonial-5">Read More</button></p>
+            <blockquote id="testimonial-5" class="testimonial-full" hidden tabindex="-1">
             <p>"Mike is one of the most versatile, professional, and driven filmmakers I've ever worked with. I've seen him do great jobs with both scripted and improv comedy, drama, and commercials as well as straight-ahead corporate. He makes the most of the actors and craftspeople he works with (and has introduced me to some excellent ones), and delivers more than expected for the budget. Even more impressive: when not working for clients, he creates interesting projects on his own. That's love."</p>
             </blockquote>
-            <p class="testimonial-author"><strong>- Jay Rose, </strong><br>Sound Designer, Digital Playroom</p>
             </div>
         </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 clickable: true
             },
             autoplay: {
-                delay: 5000,
+                delay: 6000,
                 disableOnInteraction: false
             },
             breakpoints: {
@@ -136,6 +136,23 @@ document.querySelectorAll('.bio-toggle').forEach(btn => {
         const expanded = card.classList.toggle('expanded');
         btn.setAttribute('aria-expanded', expanded);
         btn.textContent = expanded ? 'Show Less' : 'Read More';
+    });
+});
+
+// Testimonial "Read More" toggle
+document.querySelectorAll('.testimonial-toggle').forEach(btn => {
+    const card = btn.closest('.testimonial-card');
+    const full = card.querySelector('.testimonial-full');
+    btn.addEventListener('click', () => {
+        const expanded = card.classList.toggle('expanded');
+        btn.setAttribute('aria-expanded', expanded);
+        btn.textContent = expanded ? 'Show Less' : 'Read More';
+        if (full) {
+            full.hidden = !expanded;
+            if (expanded) {
+                full.focus();
+            }
+        }
     });
 });
 

--- a/styles.css
+++ b/styles.css
@@ -189,6 +189,10 @@ p {
 
 /* ===== Responsive Navigation ===== */
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .nav-toggle {
         display: block;
     }
@@ -385,6 +389,10 @@ p {
 
 /* Responsive Adjustments for Work Samples */
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .work-samples-grid {
         grid-template-columns: 1fr;
     }
@@ -559,7 +567,35 @@ p {
     line-height: 1.6;
 }
 
+.testimonial-excerpt {
+    margin-bottom: 0.5rem;
+}
+
+.testimonial-full {
+    display: none;
+}
+
+.testimonial-card.expanded .testimonial-full {
+    display: block;
+}
+
+.testimonial-toggle {
+    background: none;
+    border: none;
+    color: var(--color-accent);
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.testimonial-toggle:focus {
+    outline: 2px solid var(--color-accent);
+}
+
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .testimonial-card {
         text-align: center;
         padding: 1.5rem;
@@ -663,6 +699,10 @@ p {
 }
 
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .bio-card .bio-content {
         display: none;
     }
@@ -672,6 +712,10 @@ p {
 }
 
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .bio-cards {
         grid-template-columns: 1fr;
         gap: 1.5rem;
@@ -804,6 +848,10 @@ p {
 }
 
 @media (max-width: 768px) {
+    .swiper-button-prev,
+    .swiper-button-next {
+        display: none;
+    }
     .social-highlights-section .embed-grid {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## Summary
- add excerpt markup to testimonials with `Read More` toggle
- style carousel excerpts and hide nav buttons on mobile
- support expand/collapse with JS and adjust autoplay delay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687141965b1c83288bd8c8a29e811a04