### PR TITLE
Refactor bio accordion summary behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,10 @@
             <div class="bio-card" data-aos="fade-up">
                 <h2 class="card-title">About Me</h2>
                 <div class="bio-content">
-                   <p>Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong> I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch. </p>
+                   <p class="bio-summary">Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong></p>
+                   <div class="bio-details">
+                       I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch.
+                   </div>
                 </div>
                 <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>
@@ -302,7 +305,10 @@
             <div class="bio-card" data-aos="fade-up" data-aos-delay="200">
                 <h2 class="card-title">Experience</h2>
                 <div class="bio-content">
-                   <p>My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong> I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>. </p>
+                   <p class="bio-summary">My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong></p>
+                   <div class="bio-details">
+                       I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>.
+                   </div>
                 </div>
                 <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>
@@ -310,13 +316,15 @@
             <div class="bio-card" data-aos="fade-up" data-aos-delay="300">
                 <h2 class="card-title">Skills</h2>
                 <div class="bio-content">
-                    <ul>
-                        <li><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</li>
-                        <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
-                        <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
-                        <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>
-                        <li><strong>Global Storytelling:</strong> Expertise in culturally adaptive content creation for diverse audiences.</li>
-                    </ul>
+                    <p class="bio-summary"><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</p>
+                    <div class="bio-details">
+                        <ul>
+                            <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
+                            <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
+                            <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>
+                            <li><strong>Global Storytelling:</strong> Expertise in culturally adaptive content creation for diverse audiences.</li>
+                        </ul>
+                    </div>
                 </div>
                 <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>

--- a/script.js
+++ b/script.js
@@ -142,11 +142,14 @@ if (navToggle && navList) {
 // Bio card toggle for mobile
 document.querySelectorAll('.bio-toggle').forEach(btn => {
     const card = btn.closest('.bio-card');
-    const content = card.querySelector('.bio-content');
+    const details = card.querySelector('.bio-details');
     btn.addEventListener('click', () => {
         const expanded = card.classList.toggle('expanded');
         btn.setAttribute('aria-expanded', expanded);
-        btn.textContent = expanded ? 'Show Less' : 'Read More';
+        btn.textContent = expanded ? 'Read Less' : 'Read More';
+        if (details) {
+            details.hidden = !expanded;
+        }
     });
 });
 

--- a/styles.css
+++ b/styles.css
@@ -737,6 +737,15 @@ p {
     line-height: 1.6;
 }
 
+.bio-summary {
+    margin-bottom: 0.5rem;
+}
+
+.bio-details {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
 .bio-card ul {
     list-style: disc;
     padding-left: 1.5rem;
@@ -772,11 +781,11 @@ p {
     .swiper-button-next {
         display: none;
     }
-    .bio-card .bio-content {
-        display: none;
+    .bio-details {
+        max-height: 0;
     }
-    .bio-card.expanded .bio-content {
-        display: block;
+    .bio-card.expanded .bio-details {
+        max-height: 100vh;
     }
 }
 


### PR DESCRIPTION
## Summary
- always display the bio summary and toggle only remaining details
- style `.bio-summary` and `.bio-details` for responsive accordions
- update script to only toggle `.bio-details`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68715f80e10083289431444cb823e98a