### PR TITLE
Add video sitemap generator script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/validate-html.js"
+    "test": "node test/validate-html.js",
+    "generate-video-sitemap": "node scripts/generateVideoSitemap.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generateVideoSitemap.js
+++ b/scripts/generateVideoSitemap.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+
+function escapeXml(str) {
+  return str.replace(/[<>&'"]/g, ch => {
+    switch (ch) {
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '&': return '&amp;';
+      case '"': return '&quot;';
+      case "'": return '&apos;';
+      default: return ch;
+    }
+  });
+}
+
+const videos = JSON.parse(fs.readFileSync('videos.json', 'utf8'));
+
+let xml = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+xml += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n`;
+xml += `        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n`;
+
+videos.forEach(video => {
+  xml += `  <url>\n`;
+  xml += `    <loc>${escapeXml(video.pageUrl)}</loc>\n`;
+  xml += `    <video:video>\n`;
+  xml += `      <video:player_loc>${escapeXml(video.playerUrl)}</video:player_loc>\n`;
+  xml += `      <video:thumbnail_loc>${escapeXml(video.thumbnailUrl)}</video:thumbnail_loc>\n`;
+  xml += `      <video:title>${escapeXml(video.title)}</video:title>\n`;
+  if (video.description) {
+    xml += `      <video:description>${escapeXml(video.description)}</video:description>\n`;
+  }
+  if (video.duration != null) {
+    xml += `      <video:duration>${video.duration}</video:duration>\n`;
+  }
+  if (video.uploadDate) {
+    xml += `      <video:publication_date>${escapeXml(video.uploadDate)}</video:publication_date>\n`;
+  }
+  xml += `    </video:video>\n`;
+  xml += `  </url>\n`;
+});
+
+xml += `</urlset>\n`;
+
+fs.writeFileSync('video-sitemap.xml', xml, 'utf8');
+console.log(`Generated video-sitemap.xml with ${videos.length} entries.`);
+

--- a/video-sitemap.xml
+++ b/video-sitemap.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/1078827186</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/1078827186.jpg</video:thumbnail_loc>
+      <video:title>A Ronin Story</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/1071453736</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/1071453736.jpg</video:thumbnail_loc>
+      <video:title>Growing - Time Is An Asset Campaign</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/8563489</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/8563489.jpg</video:thumbnail_loc>
+      <video:title>Educational Multimedia Project</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/231089330</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/231089330.jpg</video:thumbnail_loc>
+      <video:title>Bear Spot Farm Project</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/1071451245</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/1071451245.jpg</video:thumbnail_loc>
+      <video:title>Crafting - Time Is An Asset Campaign</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/1029449968</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/1029449968.jpg</video:thumbnail_loc>
+      <video:title>Like Me! by Michael Kuell</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/366306782</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/366306782.jpg</video:thumbnail_loc>
+      <video:title>UTC Annual Report - UTAS</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://player.vimeo.com/video/156855931</video:player_loc>
+      <video:thumbnail_loc>https://vumbnail.com/156855931.jpg</video:thumbnail_loc>
+      <video:title>Pfizer Update - Sally Sussman</video:title>
+    </video:video>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- generate `video-sitemap.xml` from `videos.json`
- expose npm script to generate sitemap

## Testing
- `npm run generate-video-sitemap`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871b001c62483289ca5e5802400eaac