### PR TITLE
Add script for IndexNow ping

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "node test/validate-html.js",
     "generate-video-sitemap": "node scripts/generateVideoSitemap.js",
-    "update-robots": "node scripts/updateRobots.js"
+    "update-robots": "node scripts/updateRobots.js",
+    "ping-indexnow": "node scripts/pingIndexNow.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/pingIndexNow.js
+++ b/scripts/pingIndexNow.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const https = require('https');
+
+const key = fs.readFileSync('indexnow.txt', 'utf8').trim();
+
+const urlList = [
+  'https://michaelkuell.com/video-sitemap.xml',
+  'https://michaelkuell.com/'
+];
+
+const data = JSON.stringify({
+  host: 'michaelkuell.com',
+  key,
+  keyLocation: 'https://michaelkuell.com/indexnow.txt',
+  urlList
+});
+
+const options = {
+  hostname: 'api.indexnow.org',
+  path: '/indexnow',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(data)
+  }
+};
+
+const req = https.request(options, res => {
+  let body = '';
+  res.on('data', chunk => { body += chunk; });
+  res.on('end', () => {
+    console.log('Response:', res.statusCode, body);
+  });
+});
+
+req.on('error', err => {
+  console.error('Error:', err.message);
+});
+
+req.write(data);
+req.end();


### PR DESCRIPTION
## Summary
- add Node.js script to ping IndexNow API
- register npm script `ping-indexnow` to run it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871b9885f08832895fe8f5976440afc