### PR TITLE
Add hero A/B variant support

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,13 +110,20 @@
             Your browser does not support the video tag. Please update your browser.
         </video>
 
-        <!-- Overlay Content -->
-        <div class="overlay hero-panel">
-            <h1 class="tagline">Video that Connects | Michael Kuell</h1>
-            <div class="intro-panel">
-                <p class="hero-intro">As a Content Producer &amp; Director, I turn complex ideas into stories that resonate with audiences, elevate brands, and flex to meet new challenges as projects evolve.</p>
-                <a href="#work-samples" class="cta-button cta-scroll">See My Work</a>
-            </div>
+        <!-- Hero Variant A -->
+        <div id="hero-variant-a" class="hero hero--variant-a hidden" aria-label="Introductory tagline">
+            <h1 class="hero__tagline">I craft video that connects brands &amp; audiences.</h1>
+            <button class="hero__cta hero__cta--primary" onclick="scrollTo('#work-samples')">See My Reel</button>
+            <button class="hero__cta hero__cta--secondary" onclick="scrollTo('#contact')">Let’s Collaborate</button>
+        </div>
+    </section>
+
+    <!-- Hero Variant B: Quick Pitch -->
+    <section id="quick-pitch" class="quick-pitch hidden" aria-label="Quick Pitch">
+        <div class="quick-pitch__content">
+            “I’m a Content Producer &amp; Director who turns complex ideas into compelling stories that resonate with audiences and elevate brand messaging. My process begins with clear goals—and stays flexible to adapt and solve challenges as projects evolve.”
+            <button class="quick-pitch__cta quick-pitch__cta--primary" onclick="scrollTo('#work-samples')">See My Reel</button>
+            <button class="quick-pitch__cta quick-pitch__cta--secondary" onclick="scrollTo('#contact')">Let’s Collaborate</button>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -1,13 +1,39 @@
 // script.js
 
+// Global hero variant flag - switch between 'A' and 'B'
+// Example: window.HERO_VARIANT = 'B';
+window.HERO_VARIANT = window.HERO_VARIANT || 'A';
+
+// Preserve native scrollTo and extend it so strings scroll to selectors
+const nativeScrollTo = window.scrollTo.bind(window);
+window.scrollTo = function(arg1, arg2) {
+    if (typeof arg1 === 'string') {
+        const el = document.querySelector(arg1);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
+        return;
+    }
+    nativeScrollTo(arg1, arg2);
+};
+
 // Wait for the DOM to load
 document.addEventListener('DOMContentLoaded', () => {
     // Add 'loaded' class so the CSS fade-in effect can start
     document.body.classList.add('loaded');
 
-    const heroOverlay = document.querySelector('.overlay');
-    if (heroOverlay) {
-        heroOverlay.classList.add('show');
+    const heroA = document.getElementById('hero-variant-a');
+    const quickPitch = document.getElementById('quick-pitch');
+    if (window.HERO_VARIANT === 'A') {
+        if (heroA) {
+            heroA.classList.remove('hidden');
+            heroA.classList.add('active', 'show');
+        }
+    } else if (window.HERO_VARIANT === 'B') {
+        if (quickPitch) {
+            quickPitch.classList.remove('hidden');
+            quickPitch.classList.add('active');
+        }
     }
 
     // Smooth scroll for hero CTA

--- a/styles.css
+++ b/styles.css
@@ -21,10 +21,10 @@
     --transition-duration: 0.4s;
     --nav-height: 50px;
 
-    /* Hero Panel */
-    --hero-panel-padding: 2rem;
-    --hero-panel-max-width: 80%;
-    --hero-panel-bg: rgba(0, 0, 0, 0.4);
+    /* Hero Variants */
+    --hero-padding: 2rem;
+    --hero-max-width: 80%;
+    --hero-overlay-opacity: 0.3;
 }
 
 /* ===== Dark Mode Variables ===== */
@@ -91,6 +91,11 @@ p {
     font-size: 1rem;
     line-height: 1.8;
     color: var(--color-text);
+}
+
+.hidden {
+    display: none !important;
+    visibility: hidden !important;
 }
 
 [data-aos] {
@@ -451,68 +456,104 @@ p {
     background-size: cover;
 }
 
-.overlay {
-    padding: var(--hero-panel-padding);
-    max-width: var(--hero-panel-max-width);
+.hero {
+    padding: var(--hero-padding);
+    max-width: var(--hero-max-width);
     margin: 0 auto;
-    background: var(--hero-panel-bg);
-    backdrop-filter: blur(3px);
+    background: rgba(0, 0, 0, var(--hero-overlay-opacity));
+    backdrop-filter: blur(3px) brightness(0.8);
     color: var(--color-text-dark);
     border-radius: 8px;
     z-index: 2;
     opacity: 0;
 }
 
-.overlay.show {
+.hero.show {
     animation: fadeInOverlay 1.5s ease forwards;
 }
 
-.tagline {
-    color: var(--color-text-dark);
+.hero__tagline {
     font-size: 1.8rem;
     margin-bottom: 1rem;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
-.intro-panel {
-    max-width: 700px;
-    margin: 0 auto;
+.hero__cta {
+    display: inline-block;
+    margin: 0.5rem;
+    padding: 0.5rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    font-family: var(--font-body);
+    cursor: pointer;
+    transition: background-color var(--transition-duration) ease;
 }
 
-.hero-intro {
+.hero__cta--primary {
+    background-color: var(--color-accent);
     color: var(--color-text-dark);
-    margin-bottom: 1rem;
-    line-height: 1.5;
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+.hero__cta--secondary {
+    background-color: transparent;
+    color: var(--color-text-dark);
+    border: 2px solid var(--color-text-dark);
+}
+
+.hero__cta:hover,
+.hero__cta:focus {
+    background-color: #005f92;
 }
 
 @media (max-width: 768px) {
-    .tagline {
+    .hero__tagline {
         font-size: 1.4rem;
-    }
-    .hero-intro {
-        font-size: 0.95rem;
     }
 }
 
-.intro-panel {
-    max-width: 700px;
+@media (max-width: 480px) {
+    .hero__cta {
+        display: block;
+        width: 100%;
+    }
+}
+
+/* ===== Quick Pitch Section ===== */
+.quick-pitch {
+    padding: 2rem;
+    text-align: center;
+}
+
+.quick-pitch__content {
+    max-width: 800px;
     margin: 0 auto;
 }
 
-.hero-intro {
-    color: var(--color-text-dark);
-    margin-bottom: 1rem;
-    line-height: 1.5;
+.quick-pitch__cta {
+    display: inline-block;
+    margin: 0.5rem;
+    padding: 0.5rem 1.5rem;
+    border-radius: 4px;
+    font-family: var(--font-body);
+    cursor: pointer;
+    transition: background-color var(--transition-duration) ease;
 }
 
-@media (max-width: 768px) {
-    .tagline {
-        font-size: 1.4rem;
-    }
-    .hero-intro {
-        font-size: 0.95rem;
-    }
+.quick-pitch__cta--primary {
+    background-color: var(--color-accent);
+    color: var(--color-text-dark);
+    border: none;
+}
+
+.quick-pitch__cta--secondary {
+    background-color: transparent;
+    color: var(--color-text-dark);
+    border: 2px solid var(--color-text-dark);
+}
+
+.quick-pitch__cta:hover,
+.quick-pitch__cta:focus {
+    background-color: #005f92;
 }
 
 .cta-button {


### PR DESCRIPTION
## Summary
- add new hero variant A overlay and variant B quick-pitch
- toggle variants at runtime using `window.HERO_VARIANT`
- style hero and quick-pitch blocks with BEM classes
- extend `scrollTo` for smooth section scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68727f8be39c83288dd8ce11876caade