### PR TITLE
Implement micro-tagline hero overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,22 +110,16 @@
             Your browser does not support the video tag. Please update your browser.
         </video>
 
-        <!-- Hero Variant A -->
-        <div id="hero-variant-a" class="hero hero--variant-a hidden" aria-label="Introductory tagline">
-            <h1 class="hero__tagline">I craft video that connects brands &amp; audiences.</h1>
-            <button class="hero__cta hero__cta--primary" onclick="scrollTo('#work-samples')">See My Reel</button>
-            <button class="hero__cta hero__cta--secondary" onclick="scrollTo('#contact')">Let’s Collaborate</button>
+        <!-- Hero Overlay -->
+        <div class="hero__overlay" aria-label="Introductory tagline">
+          <h1 class="hero__tagline">I craft video that connects brands &amp; audiences.</h1>
+          <div class="hero__buttons">
+            <button class="hero__cta hero__cta--primary" onclick="scrollTo('#work-samples')" aria-label="See my reel">See My Reel</button>
+            <button class="hero__cta hero__cta--secondary" onclick="scrollTo('#contact')" aria-label="Let’s Collaborate">Let’s Collaborate</button>
+          </div>
         </div>
     </section>
 
-    <!-- Hero Variant B: Quick Pitch -->
-    <section id="quick-pitch" class="quick-pitch hidden" aria-label="Quick Pitch">
-        <div class="quick-pitch__content">
-            “I’m a Content Producer &amp; Director who turns complex ideas into compelling stories that resonate with audiences and elevate brand messaging. My process begins with clear goals—and stays flexible to adapt and solve challenges as projects evolve.”
-            <button class="quick-pitch__cta quick-pitch__cta--primary" onclick="scrollTo('#work-samples')">See My Reel</button>
-            <button class="quick-pitch__cta quick-pitch__cta--secondary" onclick="scrollTo('#contact')">Let’s Collaborate</button>
-        </div>
-    </section>
 
         <!-- Work Samples Section -->
 <section id="work-samples" class="work-samples-section" role="region" aria-labelledby="work-samples-heading">

--- a/script.js
+++ b/script.js
@@ -1,8 +1,5 @@
 // script.js
 
-// Global hero variant flag - switch between 'A' and 'B'
-// Example: window.HERO_VARIANT = 'B';
-window.HERO_VARIANT = window.HERO_VARIANT || 'A';
 
 // Preserve native scrollTo and extend it so strings scroll to selectors
 const nativeScrollTo = window.scrollTo.bind(window);
@@ -22,30 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add 'loaded' class so the CSS fade-in effect can start
     document.body.classList.add('loaded');
 
-    const heroA = document.getElementById('hero-variant-a');
-    const quickPitch = document.getElementById('quick-pitch');
-    if (window.HERO_VARIANT === 'A') {
-        if (heroA) {
-            heroA.classList.remove('hidden');
-            heroA.classList.add('active', 'show');
-        }
-    } else if (window.HERO_VARIANT === 'B') {
-        if (quickPitch) {
-            quickPitch.classList.remove('hidden');
-            quickPitch.classList.add('active');
-        }
+    const overlay = document.querySelector('.hero__overlay');
+    if (overlay) {
+        overlay.style.visibility = 'visible';
+        overlay.classList.add('show');
     }
 
-    // Smooth scroll for hero CTA
-    document.querySelectorAll('.cta-scroll').forEach(btn => {
-        btn.addEventListener('click', e => {
-            const target = document.querySelector(btn.getAttribute('href'));
-            if (target) {
-                e.preventDefault();
-                target.scrollIntoView({ behavior: 'smooth' });
-            }
-        });
-    });
 
     // Dynamic Year in Footer
     const yearSpan = document.getElementById('current-year');

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@
     --color-text-light: #333333;
     --color-accent: #0077b6;
     --color-muted: #c4c4c4;
+    --color-white: #ffffff;
 
     /* Transition & Layout */
     --transition-duration: 0.4s;
@@ -456,105 +457,58 @@ p {
     background-size: cover;
 }
 
-.hero {
-    padding: var(--hero-padding);
-    max-width: var(--hero-max-width);
-    margin: 0 auto;
-    background: rgba(0, 0, 0, var(--hero-overlay-opacity));
-    backdrop-filter: blur(3px) brightness(0.8);
-    color: var(--color-text-dark);
-    border-radius: 8px;
-    z-index: 2;
-    opacity: 0;
+
+.hero__overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: var(--hero-max-width, 80%);
+    padding: var(--hero-padding, 1rem);
+    background-color: rgba(0, 0, 0, var(--hero-overlay-opacity, 0.3));
+    text-align: center;
+    color: var(--color-white);
+    visibility: hidden;
 }
 
-.hero.show {
+.hero__overlay.show {
     animation: fadeInOverlay 1.5s ease forwards;
 }
 
 .hero__tagline {
-    font-size: 1.8rem;
     margin-bottom: 1rem;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+    font-size: 2rem;
+}
+
+.hero__buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
 }
 
 .hero__cta {
-    display: inline-block;
-    margin: 0.5rem;
-    padding: 0.5rem 1.5rem;
-    border: none;
-    border-radius: 4px;
-    font-family: var(--font-body);
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
     cursor: pointer;
-    transition: background-color var(--transition-duration) ease;
+    border: none;
 }
 
 .hero__cta--primary {
-    background-color: var(--color-accent);
-    color: var(--color-text-dark);
+    background-color: var(--accent-color, var(--color-accent));
+    color: #fff;
 }
 
 .hero__cta--secondary {
     background-color: transparent;
-    color: var(--color-text-dark);
-    border: 2px solid var(--color-text-dark);
-}
-
-.hero__cta:hover,
-.hero__cta:focus {
-    background-color: #005f92;
-}
-
-@media (max-width: 768px) {
-    .hero__tagline {
-        font-size: 1.4rem;
-    }
+    color: #fff;
+    border: 2px solid #fff;
 }
 
 @media (max-width: 480px) {
-    .hero__cta {
-        display: block;
-        width: 100%;
-    }
+    .hero__tagline { font-size: 1.5rem; }
+    .hero__buttons { flex-direction: column; }
 }
 
-/* ===== Quick Pitch Section ===== */
-.quick-pitch {
-    padding: 2rem;
-    text-align: center;
-}
-
-.quick-pitch__content {
-    max-width: 800px;
-    margin: 0 auto;
-}
-
-.quick-pitch__cta {
-    display: inline-block;
-    margin: 0.5rem;
-    padding: 0.5rem 1.5rem;
-    border-radius: 4px;
-    font-family: var(--font-body);
-    cursor: pointer;
-    transition: background-color var(--transition-duration) ease;
-}
-
-.quick-pitch__cta--primary {
-    background-color: var(--color-accent);
-    color: var(--color-text-dark);
-    border: none;
-}
-
-.quick-pitch__cta--secondary {
-    background-color: transparent;
-    color: var(--color-text-dark);
-    border: 2px solid var(--color-text-dark);
-}
-
-.quick-pitch__cta:hover,
-.quick-pitch__cta:focus {
-    background-color: #005f92;
-}
 
 .cta-button {
     display: inline-block;


### PR DESCRIPTION
## Summary
- replace A/B hero sections with a single overlay
- style new `.hero__overlay` component
- expose overlay via JS after DOM load
- remove old quick-pitch styles and JS logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872856b83908328ae149ae9b432e2b0