### PR TITLE
Replace Bio with new About accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
             <!-- Navigation Links -->
             <ul class="nav-list">
                 <li><a href="https://michaelkuell.com/#testimonials" title="Read testimonials for Michael Kuell">Testimonials</a></li>
-                <li><a href="https://michaelkuell.com/#bio" title="Learn more about Michael Kuell">Bio</a></li>
+                <li><a href="https://michaelkuell.com/#about" title="Learn more about Michael Kuell">About</a></li>
                 <li>
                     <!-- Dark Mode Toggle -->
                     <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">
@@ -287,47 +287,26 @@
     </div>
 
  <!-- Bio Section -->
-<section id="bio" class="bio-section" role="region" aria-labelledby="bio-heading">
-    <div class="bio-container">
-        <h2 id="bio-heading" class="section-title" data-aos="fade-up">     BIO</h2>
-        <div class="bio-cards">
-            <!-- About Me Card -->
-            <div class="bio-card" data-aos="fade-up">
-                <h2 class="card-title">About Me</h2>
-                <div class="bio-content">
-                   <p class="bio-summary">Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong></p>
-                   <div class="bio-details">
-                       I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch.
-                   </div>
-                </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
+<section id="about" class="about">
+    <h2 class="about__header">About</h2>
+    <div class="about__accordion">
+        <div class="about__item">
+            <button id="exp-toggle" class="about__toggle" aria-expanded="false" aria-controls="exp-panel">Experience</button>
+            <div id="exp-panel" class="about__panel" role="region" aria-labelledby="exp-toggle">
+                <p>My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong></p>
+                <p>I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>.</p>
             </div>
-            <!-- Experience Card -->
-            <div class="bio-card" data-aos="fade-up" data-aos-delay="200">
-                <h2 class="card-title">Experience</h2>
-                <div class="bio-content">
-                   <p class="bio-summary">My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong></p>
-                   <div class="bio-details">
-                       I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>.
-                   </div>
-                </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
-            </div>
-            <!-- Skills Card -->
-            <div class="bio-card" data-aos="fade-up" data-aos-delay="300">
-                <h2 class="card-title">Skills</h2>
-                <div class="bio-content">
-                    <p class="bio-summary"><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</p>
-                    <div class="bio-details">
-                        <ul>
-                            <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
-                            <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
-                            <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>
-                            <li><strong>Global Storytelling:</strong> Expertise in culturally adaptive content creation for diverse audiences.</li>
-                        </ul>
-                    </div>
-                </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
+        </div>
+        <div class="about__item">
+            <button id="skills-toggle" class="about__toggle" aria-expanded="false" aria-controls="skills-panel">Skills</button>
+            <div id="skills-panel" class="about__panel" role="region" aria-labelledby="skills-toggle">
+                <p><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</p>
+                <ul>
+                    <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
+                    <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
+                    <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>
+                    <li><strong>Global Storytelling:</strong> Expertise in culturally adaptive content creation for diverse audiences.</li>
+                </ul>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -144,16 +144,19 @@ if (navToggle && navList) {
     });
 }
 
-// Bio card toggle for mobile
-document.querySelectorAll('.bio-toggle').forEach(btn => {
-    const card = btn.closest('.bio-card');
-    const details = card.querySelector('.bio-details');
+// About accordion toggle
+const toggles = document.querySelectorAll('.about__toggle');
+toggles.forEach(btn => {
     btn.addEventListener('click', () => {
-        const expanded = card.classList.toggle('expanded');
-        btn.setAttribute('aria-expanded', expanded);
-        btn.textContent = expanded ? 'Read Less' : 'Read More';
-        if (details) {
-            details.hidden = !expanded;
+        const expanded = btn.getAttribute('aria-expanded') === 'true';
+        toggles.forEach(t => t.setAttribute('aria-expanded', 'false'));
+        document.querySelectorAll('.about__panel').forEach(p => p.style.maxHeight = null);
+        if (!expanded) {
+            btn.setAttribute('aria-expanded', 'true');
+            const panel = document.getElementById(btn.getAttribute('aria-controls'));
+            if (panel) {
+                panel.style.maxHeight = panel.scrollHeight + 'px';
+            }
         }
     });
 });

--- a/styles.css
+++ b/styles.css
@@ -676,8 +676,8 @@ p {
     }
 }
 
-/* ===== Bio Section ===== */
-.bio-section {
+/* ===== About Section ===== */
+.about {
     background: url('assets/images/MK_background.jpg') center center / cover no-repeat fixed;
     padding: 4rem 2rem;
     position: relative;
@@ -688,7 +688,7 @@ p {
     overflow: hidden;
 }
 
-.bio-section::before {
+.about::before {
     content: '';
     position: absolute;
     top: 0;
@@ -700,108 +700,40 @@ p {
     animation: fadeInOverlay 2.5s ease-in-out forwards;
 }
 
-.bio-cards {
+.about__accordion {
     position: relative;
     z-index: 2;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2rem;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem;
+    max-width: 800px;
+    width: 100%;
 }
 
-.bio-card {
+.about__item + .about__item {
+    margin-top: 1rem;
+}
+
+.about__toggle {
+    width: 100%;
+    background-color: var(--color-accent);
+    color: var(--color-text-dark);
+    border: none;
+    padding: 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+}
+
+.about__panel {
     background: rgba(200, 205, 217, 0.6);
     backdrop-filter: blur(8px);
-    padding: 2rem;
-    border-radius: 12px;
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.bio-card h2 {
-    font-size: 1.8rem;
-    margin-bottom: 0.8rem;
-    color: var(--color-text-dark);
-}
-
-.bio-card p, .bio-card ul {
-    font-size: 1rem;
-    color: var(--color-text);
-    line-height: 1.6;
-}
-
-.bio-summary {
-    margin-bottom: 0.5rem;
-}
-
-.bio-details {
+    padding: 1rem;
+    margin-bottom: 1rem;
+    max-height: 0;
     overflow: hidden;
     transition: max-height 0.3s ease;
 }
 
-.bio-card ul {
-    list-style: disc;
-    padding-left: 1.5rem;
-    margin-bottom: 1rem;
-}
-
-.bio-toggle {
-    margin-top: 1rem;
-    background-color: var(--color-accent);
-    color: var(--color-text-dark);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.bio-toggle:hover {
-    background-color: #005f92;
-}
-
-.bio-toggle:focus {
-    outline: 2px solid var(--color-accent);
-}
-
-@media (min-width: 769px) {
-    .bio-toggle {
-        display: none;
-    }
-}
-
-@media (max-width: 768px) {
-    .swiper-button-prev,
-    .swiper-button-next {
-        display: none;
-    }
-    .bio-details {
-        max-height: 0;
-    }
-    .bio-card.expanded .bio-details {
-        max-height: 100vh;
-    }
-}
-
-@media (max-width: 768px) {
-    .swiper-button-prev,
-    .swiper-button-next {
-        display: none;
-    }
-    .bio-cards {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
-    .bio-card {
-        padding: 1.5rem;
-    }
-    .bio-card h2 {
-        font-size: 1.4rem;
-    }
-    .bio-card p, .bio-card ul {
-        font-size: 0.9rem;
-    }
+.about__toggle[aria-expanded="true"] + .about__panel {
+    max-height: 100vh;
 }
 
 


### PR DESCRIPTION
## Summary
- convert Bio section into new About accordion with Experience and Skills
- rename navigation link to About
- style About section with accordion classes
- add JS logic for new accordion behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687296499c308328a79641379d6623f5