### PR TITLE
Fix 404 page footer year

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,7 +12,11 @@
         <p>    💾💾💾💾💾 💾   Bummer.  💾💾💾💾💾💾 Please check the <strong>URL</strong> or go back to the <a href="/">home page</a>.</p>
     </header>
     <footer>
-        <p>&copy; 2025 Michael Kuell. All rights reserved.</p>
+        <p>&copy; <span id="current-year"></span> Michael Kuell. All rights reserved.</p>
     </footer>
+    <script>
+        // Insert the current year dynamically, mirroring index.html logic
+        document.getElementById('current-year').textContent = new Date().getFullYear();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use the same dynamic year logic as the homepage for 404.html

## Testing
- `npm test`
- `node - <<'EOF'
const {JSDOM} = require('jsdom');
const fs = require('fs');
const html = fs.readFileSync('404.html', 'utf8');
const dom = new JSDOM(html, {runScripts: "dangerously"});
const yearText = dom.window.document.querySelector('#current-year').textContent;
console.log('year:', yearText);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6872a91a5de88328b83894d95d3afe51