### PR TITLE
Add sticky responsive nav with scroll spy

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,33 +76,37 @@
 <body>
     <!-- Site Header with Navigation -->
     <header class="site-header">
-        <nav class="navbar" role="navigation" aria-label="Main Navigation">
-            <!-- Logo -->
-            <div class="logo">
-                <a href="/" id="logo-link" title="Go to the top of the site">Home</a>
-            </div>
+        <!-- Logo -->
+        <div class="logo">
+            <a href="/" id="logo-link" title="Go to the top of the site">Home</a>
+        </div>
 
-            <!-- Mobile Navigation Toggle -->
-            <button class="nav-toggle" aria-label="Toggle Navigation Menu">
+        <!-- Mobile Navigation Toggle -->
+        <div class="nav__mobile-menu">
+            <button class="nav-toggle" aria-label="Toggle Navigation Menu" aria-controls="nav-menu" aria-expanded="false">
                 ☰
             </button>
+        </div>
 
-            <!-- Navigation Links -->
-            <ul class="nav-list">
-                <li><a href="#testimonials" title="Read testimonials for Michael Kuell">Testimonials</a></li>
-                <li><a href="#about" title="Learn more about Michael Kuell">About</a></li>
-                <li>
-                    <!-- Dark Mode Toggle -->
-                    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">
-                        🌙
-                    </button>
-                </li>
+        <!-- Primary Navigation -->
+        <nav class="nav" id="nav-menu" role="navigation" aria-label="Main Navigation">
+            <ul class="nav__list">
+              <li class="nav__item"><a href="#home" class="nav__link">Home</a></li>
+              <li class="nav__item"><a href="#work-samples" class="nav__link">Work Samples</a></li>
+              <li class="nav__item"><a href="#about" class="nav__link">About</a></li>
+              <li class="nav__item"><a href="#testimonials" class="nav__link">Testimonials</a></li>
+              <li class="nav__item"><a href="#contact" class="nav__link">Contact</a></li>
             </ul>
         </nav>
+
+        <!-- Dark Mode Toggle -->
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">
+            🌙
+        </button>
     </header>
     
     <!-- Cover Page Section -->
-    <section id="cover-page" class="cover-page" role="banner" aria-labelledby="cover-title">
+    <section id="home" class="cover-page" role="banner" aria-labelledby="cover-title">
         <!-- Background Video -->
         <video autoplay muted loop playsinline class="background-video" aria-label="Showreel of Michael Kuell's creative work">
             <source src="assets/videos/cover-video.webm" type="video/webm">

--- a/script.js
+++ b/script.js
@@ -46,11 +46,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Add or remove 'scrolled' class based on scroll position
+    // Add or remove background on scroll
     const siteHeader = document.querySelector('.site-header');
     if (siteHeader) {
         const toggleScrolled = () => {
-            siteHeader.classList.toggle('scrolled', window.scrollY > 0);
+            const offset = siteHeader.offsetHeight;
+            siteHeader.classList.toggle('header--scrolled', window.scrollY > offset);
         };
         window.addEventListener('scroll', toggleScrolled);
         toggleScrolled();
@@ -119,8 +120,8 @@ if (toggleButton) {
 
 // Navigation Toggle for Mobile
 const navToggle = document.querySelector('.nav-toggle');
-const navList = document.querySelector('.nav-list');
-const navLinks = document.querySelectorAll('.nav-list a');
+const navList = document.querySelector('.nav__list');
+const navLinks = document.querySelectorAll('.nav__link');
 
 if (navToggle && navList) {
     navToggle.addEventListener('click', () => {
@@ -184,13 +185,19 @@ if (navLinks.length > 0) {
         .map(link => document.querySelector(link.hash))
         .filter(Boolean);
 
-    const observerOptions = { threshold: 0.25 };
+    const observerOptions = { threshold: 0.5 };
     const observer = new IntersectionObserver(entries => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
                 const id = entry.target.id;
                 navLinks.forEach(link => {
-                    link.classList.toggle('active', link.hash === `#${id}`);
+                    const active = link.hash === `#${id}`;
+                    link.classList.toggle('nav__link--active', active);
+                    if (active) {
+                        link.setAttribute('aria-current', 'page');
+                    } else {
+                        link.removeAttribute('aria-current');
+                    }
                 });
             }
         });

--- a/styles.css
+++ b/styles.css
@@ -123,12 +123,12 @@ p {
     backdrop-filter: blur(5px);
 }
 
-.site-header.scrolled {
+.site-header.header--scrolled {
     background-color: var(--color-background);
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
-.navbar {
+.nav {
     width: 100%;
     max-width: 1200px;
     display: flex;
@@ -148,17 +148,20 @@ p {
     text-shadow: 0px 3px 6px rgba(0, 0, 0, 0.5);
 }
 
-.nav-list {
+
+.nav__list {
     list-style: none;
     display: flex;
     align-items: center;
 }
 
-.nav-list li {
+
+.nav__item {
     margin-left: 2rem;
 }
 
-.nav-list a {
+
+.nav__link {
     position: relative;
     color: var(--color-text);
     text-decoration: none;
@@ -166,11 +169,13 @@ p {
     transition: color var(--transition-duration) ease;
 }
 
-.nav-list a:hover {
+
+.nav__link:hover {
     color: var(--color-accent);
 }
 
-.nav-list a::after {
+
+.nav__link::after {
     content: "";
     position: absolute;
     left: 0;
@@ -183,13 +188,14 @@ p {
     transition: transform var(--transition-duration) ease;
 }
 
+
 /* Active navigation link */
-.nav-list a.active {
+.nav__link--active {
     color: var(--color-accent);
     font-weight: bold;
 }
 
-.nav-list a.active::after {
+.nav__link--active::after {
     transform: scaleX(1);
 }
 
@@ -202,6 +208,10 @@ p {
     cursor: pointer;
 }
 
+.nav__mobile-menu {
+    display: block;
+}
+
 /* ===== Responsive Navigation ===== */
 @media (max-width: 768px) {
     .swiper-button-prev,
@@ -212,23 +222,22 @@ p {
         display: block;
     }
 
-    .nav-list {
+    .nav__list {
+        display: none;
         position: absolute;
         top: var(--nav-height);
         right: 0;
         background-color: var(--color-muted);
         flex-direction: column;
         width: 200px;
-        max-height: 0;
-        overflow: hidden;
-        transition: max-height var(--transition-duration) ease;
+        padding: 0;
     }
 
-    .nav-list.active {
-        max-height: 500px;
+    .nav__list.active {
+        display: flex;
     }
 
-    .nav-list li {
+    .nav__item {
         margin: 1rem 0;
         text-align: right;
         margin-right: 1.5rem;
@@ -241,9 +250,15 @@ p {
         text-align: right;
     }
 
-    .nav-list.active #theme-toggle {
+    .nav__list.active #theme-toggle {
         display: block;
     }
+}
+
+@media (min-width: 768px) {
+    .nav-toggle { display: none; }
+    .nav__list { display: flex; }
+    .nav__mobile-menu { display: none; }
 }
 
 /* ===== Work Samples Section ===== */


### PR DESCRIPTION
## Summary
- implement sticky header with scroll background toggle
- update header markup for responsive navigation
- style `.nav__list` for mobile/desktop layouts
- highlight nav links for active section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872f294666c8328b231d20ea8755e41