### PR TITLE
Implement accent-color-dark in CSS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,11 +33,15 @@
 [data-theme="dark"] {
     --color-background: var(--color-background-dark);
     --color-text: var(--color-text-dark);
+    /* Brighter accent color for elements on dark backgrounds */
+    --accent-color-dark: #1e90ff;
 }
 
 [data-theme="light"] {
     --color-background: var(--color-background-light);
     --color-text: var(--color-text-light);
+    /* Use default accent for elements on dark backgrounds */
+    --accent-color-dark: var(--color-accent);
 }
 
 /* ===== General Reset ===== */
@@ -184,7 +188,7 @@ p {
     bottom: -3px;
     width: 100%;
     height: 2px;
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-dark);
     transform: scaleX(0);
     transform-origin: left;
     transition: transform var(--transition-duration) ease;
@@ -513,7 +517,7 @@ p {
 }
 
 .hero__cta--primary {
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-dark);
     color: #fff;
 }
 
@@ -531,7 +535,7 @@ p {
 
 .cta-button {
     display: inline-block;
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-dark);
     color: var(--color-text-dark);
     padding: 0.5rem 1.5rem;
     border-radius: 4px;
@@ -541,7 +545,7 @@ p {
 
 .cta-button:hover,
 .cta-button:focus {
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-dark);
 }
 
 .main-title, .sub-title, .cta-text {
@@ -591,7 +595,7 @@ p {
 
 .swiper-button-prev,
 .swiper-button-next {
-    background: var(--accent-color);
+    background: var(--accent-color-dark);
     color: var(--color-text-dark);
     border: none;
     width: 2rem;
@@ -611,7 +615,7 @@ p {
 .swiper-button-next { right: 0.5rem; }
 
 .swiper-pagination-bullet {
-    background: var(--accent-color);
+    background: var(--accent-color-dark);
     opacity: 0.5;
 }
 
@@ -736,7 +740,7 @@ p {
 
 .about__toggle {
     width: 100%;
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-dark);
     color: var(--color-text-dark);
     border: none;
     padding: 1rem;


### PR DESCRIPTION
## Summary
- define `--accent-color-dark` variable for dark/light themes
- use `accent-color-dark` for nav underline, hero CTA, CTA button, Swiper arrows, bullets, and About accordion toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873be1a9ecc83288f8392b1d112e660