### PR TITLE
Fix gitignore for package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-package-lock.json


### PR DESCRIPTION
## Summary
- stop ignoring `package-lock.json` so it stays in the repository

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874184ee5f883288ae946e451290a0a