### PR TITLE
Refresh hero section overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,11 +108,14 @@
 
         <!-- Overlay Content -->
         <div class="overlay">
-            <h1 id="cover-title" class="main-title" data-aos="fade-up">Michael Kuell</h1>
-            <h2 class="sub-title" data-aos="fade-up" data-aos-delay="200">
-                Creative Producer | Video Director | Storyteller
-            </h2>
-            <p class="cta-text" data-aos="fade-up" data-aos-delay="400">MY STORY // PORTFOLIO</p>
+            <div class="hero-overlay">
+                <h1 id="cover-title" class="main-title" data-aos="fade-up">Michael Kuell</h1>
+                <h2 class="sub-title" data-aos="fade-up" data-aos-delay="200">
+                    Creative Producer | Video Director | Storyteller
+                </h2>
+                <p class="cta-text" data-aos="fade-up" data-aos-delay="400">MY STORY // PORTFOLIO</p>
+                <a href="#work-samples" class="btn btn-primary" data-aos="fade-up" data-aos-delay="600">View Portfolio ↓</a>
+            </div>
         </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -409,11 +409,23 @@ p {
     z-index: 2;
 }
 
+.hero-overlay {
+    background: rgba(255, 255, 255, 0.8);
+    padding: 2rem;
+    border-radius: .5rem;
+}
+
+.btn-primary {
+    background: var(--color-accent);
+    color: #fff;
+    padding: .75rem 1.5rem;
+    border-radius: .25rem;
+    text-decoration: none;
+    display: inline-block;
+}
+
 .main-title, .sub-title, .cta-text {
-    background: linear-gradient(180deg, #666, #fff);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    text-shadow: none;
+    color: var(--color-text);
 }
 
 


### PR DESCRIPTION
## Summary
- add hero-overlay wrapper and CTA button in hero section
- style hero-overlay background, add button styling
- switch hero text styling to standard color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68758e9582088328934159484020e558