### PR TITLE
Improve work samples layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,73 +123,73 @@
 <section id="work-samples" class="work-samples-section" role="region" aria-labelledby="work-samples-heading">
 <h2 id="work-samples-heading" class="section-title">Work samples</h2>
     <div class="work-samples-grid">
-        <div class="work-sample">
+        <div class="work-card work-card--featured">
             <div class="video-wrapper" data-src="https://www.youtube.com/embed/zZLAUAPX044" data-title="AI Sizzle Reel">
                 <img src="https://img.youtube.com/vi/zZLAUAPX044/hqdefault.jpg" alt="Thumbnail for Mike Kuell's AI Sizzle Reel" loading="lazy">
                 <button class="play-button" aria-label="Play AI Sizzle Reel" type="button">▶</button>
           </div>
         </div>
-                <div class="work-sample">
+                <div class="work-card work-card--featured">
             <div class="video-wrapper" data-src="https://www.youtube.com/embed/fYFGi8RpYJ0" data-title="Orvis Spec Ad :Abby">
                 <img src="https://img.youtube.com/vi/fYFGi8RpYJ0/hqdefault.jpg" alt="Thumbnail for Orvis Spec Ad :Abby" loading="lazy">
                 <button class="play-button" aria-label="Play Orvis Spec Ad :Abby" type="button">▶</button>
           </div>
         </div>
-                <div class="work-sample">
+                <div class="work-card work-card--featured">
             <div class="video-wrapper" data-src="https://www.youtube.com/embed/ABl3Gv-LD64" data-title="Interviews : Capturing Authentic Expertise">
                 <img src="https://img.youtube.com/vi/ABl3Gv-LD64/hqdefault.jpg" alt="Thumbnail for Interviews : Capturing Authentic Expertise" loading="lazy">
                 <button class="play-button" aria-label="Play Interviews : Capturing Authentic Expertise" type="button">▶</button>
           </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/1078827186" data-title="A Ronin Story">
                 <img src="https://vumbnail.com/1078827186.jpg" alt="A Ronin Story" loading="lazy">
                 <button class="play-button" aria-label="Play A Ronin Story" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/1071453736" data-title="Growing - Time Is An Asset Campaign">
                 <img src="https://vumbnail.com/1071453736.jpg" alt="Growing - Time Is An Asset Campaign thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Growing - Time Is An Asset Campaign video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/8563489" data-title="Educational Multimedia Project">
                 <img src="https://vumbnail.com/8563489.jpg" alt="Educational Multimedia Project thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Educational Multimedia Project video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/231089330" data-title="Bear Spot Farm Project">
                 <img src="https://vumbnail.com/231089330.jpg" alt="Bear Spot Farm Project thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Bear Spot Farm Project video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/1071451245" data-title="Crafting - Time Is An Asset Campaign">
                 <img src="https://vumbnail.com/1071451245.jpg" alt="Crafting - Time Is An Asset Campaign thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Crafting - Time Is An Asset Campaign video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/1029449968" data-title="Like Me! by Michael Kuell">
                 <img src="https://vumbnail.com/1029449968.jpg" alt="Like Me! by Michael Kuell thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Like Me! by Michael Kuell video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/366306782" data-title="UTC Annual Report - UTAS">
                 <img src="https://vumbnail.com/366306782.jpg" alt="UTC Annual Report - UTAS thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play UTC Annual Report - UTAS video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://player.vimeo.com/video/156855931" data-title="Pfizer Update - Sally Sussman">
                 <img src="https://vumbnail.com/156855931.jpg" alt="Pfizer Update - Sally Sussman thumbnail" loading="lazy">
                 <button class="play-button" aria-label="Play Pfizer Update - Sally Sussman video" type="button">▶</button>
             </div>
         </div>
-        <div class="work-sample">
+        <div class="work-card">
             <div class="video-wrapper" data-src="https://vimeo.com/manage/videos/231087681" data-title="Nashoba Brook Bakery">
                 <img src="https://vumbnail.com/231087681.jpg" alt="Nashoba Brook Bakery Documentary" loading="lazy">
                 <button class="play-button" aria-label="Nashoba Brook Bakery" type="button">▶</button>

--- a/styles.css
+++ b/styles.css
@@ -207,7 +207,7 @@ p {
 
 /* ===== Work Samples Section ===== */
 .work-samples-section {
-    background-color: var(--color-muted);
+    background-color: #fff;
     padding: 3rem 1rem;
     max-width: 1200px;
     margin: 0 auto;
@@ -221,10 +221,10 @@ p {
     align-items: start;
 }
 
-.work-sample {
-    background-color: var(--color-bg); /* Consistent variable usage */
-    border-radius: 8px;
-    box-shadow: none;
+.work-card {
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    border-radius: .5rem;
     overflow: hidden;
     transition: transform 0.3s ease;
     display: flex;
@@ -233,9 +233,15 @@ p {
     margin-bottom: 2rem;
 }
 
-.work-sample:hover {
+.work-card:hover {
     transform: translateY(-5px);
     box-shadow: 0 8px 16px rgba(0, 0, 50, 0.4);
+}
+
+@media (min-width: 768px) {
+    .work-card--featured {
+        grid-column: span 2;
+    }
 }
 
 /* Video Wrapper */
@@ -366,7 +372,7 @@ p {
     .work-samples-grid {
         grid-template-columns: 1fr;
     }
-    .work-sample {
+    .work-card {
         margin-bottom: 1.5rem;
     }
     .video-wrapper {


### PR DESCRIPTION
## Summary
- use `.work-card` for work items
- highlight featured items on desktop
- lighten work samples background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68759002de688328a521a57ae42e2a23