### PR TITLE
Remove orphan HTML classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 
         <!-- Work Samples Section -->
 <section id="work-samples" class="work-samples-section" role="region" aria-labelledby="work-samples-heading">
-<h2 id="work-samples-heading" class="section-title">Work samples</h2>
+<h2 id="work-samples-heading">Work samples</h2>
     <div class="work-samples-grid">
         <div class="work-card work-card--featured">
             <div class="video-wrapper" data-src="https://www.youtube.com/embed/zZLAUAPX044" data-title="AI Sizzle Reel">
@@ -197,14 +197,13 @@
 </section>
     <!-- Divider: Work Samples to Testimonials -->
     <div class="section-divider divider-wave" aria-hidden="true">
-        <img src="assets/images/divider-wave.svg" alt="" class="divider-img">
+        <img src="assets/images/divider-wave.svg" alt="">
     </div>
 
 <!-- Testimonials Section -->
 <section id="testimonials" class="testimonials-section" role="region" aria-labelledby="testimonials-heading">
-<h2 id="testimonials-heading" class="section-title" data-aos="fade-up">Testimonials</h2>
+<h2 id="testimonials-heading" data-aos="fade-up">Testimonials</h2>
     <div class="accordion">
-      <div class="item">
         <button class="toggle" aria-expanded="false">- Jonas Bromberg, Psy.D.<br>Principal Consultant @ Crossroads Health</button>
         <div class="content" hidden>
           <div class="testimonial-card" data-aos="flip-left">
@@ -214,8 +213,6 @@
             </blockquote>
           </div>
         </div>
-      </div>
-      <div class="item">
         <button class="toggle" aria-expanded="false">- Sonya Ponder<br>Diversity, Equity and Inclusion Talent Acquisition Manager at Princeton University</button>
         <div class="content" hidden>
           <div class="testimonial-card" data-aos="flip-left" data-aos-delay="200">
@@ -225,8 +222,6 @@
             </blockquote>
           </div>
         </div>
-      </div>
-      <div class="item">
         <button class="toggle" aria-expanded="false">- Dave Greeley<br>Partner @ McKenna and Partners</button>
         <div class="content" hidden>
           <div class="testimonial-card" data-aos="flip-left" data-aos-delay="300">
@@ -236,8 +231,6 @@
             </blockquote>
           </div>
         </div>
-      </div>
-      <div class="item">
         <button class="toggle" aria-expanded="false">- Cathleen Carr<br>Creative Social Impact Leader</button>
         <div class="content" hidden>
           <div class="testimonial-card" data-aos="flip-left" data-aos-delay="400">
@@ -247,8 +240,6 @@
             </blockquote>
           </div>
         </div>
-      </div>
-      <div class="item">
         <button class="toggle" aria-expanded="false">- Jay Rose<br>Sound Designer, Digital Playroom</button>
         <div class="content" hidden>
           <div class="testimonial-card" data-aos="flip-left" data-aos-delay="400">
@@ -258,22 +249,21 @@
             </blockquote>
           </div>
         </div>
-      </div>
     </div>
 </section>
     <!-- Divider: Testimonials to Bio -->
     <div class="section-divider divider-diagonal" aria-hidden="true">
-        <img src="assets/images/divider-diagonal.svg" alt="" class="divider-img">
+        <img src="assets/images/divider-diagonal.svg" alt="">
     </div>
 
  <!-- Bio Section -->
 <section id="bio" class="bio-section" role="region" aria-labelledby="bio-heading">
-    <div class="bio-container">
-        <h2 id="bio-heading" class="section-title" data-aos="fade-up">Bio</h2>
+    <div>
+        <h2 id="bio-heading" data-aos="fade-up">Bio</h2>
         <div class="bio-cards">
             <!-- About Me Card -->
             <div class="bio-card" data-aos="fade-up">
-                <h2 class="card-title">About Me</h2>
+                <h2>About Me</h2>
                 <div class="bio-content">
                    <p>I believe a great project starts with clear <strong>goals</strong> and thoughtful <strong>planning</strong> but evolves with the <strong>flexibility</strong> to adapt and solve challenges along the way. Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong> I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch. </p>
                 </div>
@@ -281,7 +271,7 @@
             </div>
             <!-- Experience Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="200">
-                <h2 class="card-title">Experience</h2>
+                <h2>Experience</h2>
                 <div class="bio-content">
                    <p>I am a <strong>Multimedia Producer and Director</strong> with a knack for turning complex ideas into engaging content that connects with audiences and elevates <strong>brand messaging</strong>. My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong> I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>. </p>
                 </div>
@@ -289,7 +279,7 @@
             </div>
             <!-- Skills Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="300">
-                <h2 class="card-title">Skills</h2>
+                <h2>Skills</h2>
                 <div class="bio-content">
                     <ul>
                         <li><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</li>
@@ -330,7 +320,7 @@
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
     <p>&copy; <span id="current-year"></span> Michael Kuell</p>
-    <p class="social-links">
+    <p>
         <a href="https://www.linkedin.com/in/mikekuell" target="_blank" rel="noopener noreferrer" title="Visit Michael Kuell's LinkedIn profile" aria-label="LinkedIn" class="social-icon-link">
             <img src="assets/images/LI-In-Bug.png" alt="LinkedIn" class="contact-icon">
         </a>


### PR DESCRIPTION
## Summary
- strip unused `section-title`, `bio-container`, `card-title`, `social-links`, and `divider-img` classes
- flatten testimonials markup by dropping redundant `.item` wrappers

## Testing
- `npm install`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68766dc336b48328a8915ff8cb3d6c11