### PR TITLE
Add hero overlay and update CTA container

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
     </header>
     
     <!-- Cover Page Section -->
-    <section id="cover-page" class="cover-page" role="banner" aria-labelledby="cover-title">
+    <section id="cover-page" class="cover-page hero" role="banner" aria-labelledby="cover-title">
         <!-- Background Video -->
         <video autoplay muted loop playsinline class="background-video" aria-label="Showreel of Michael Kuell's creative work">
             <source src="assets/videos/cover-video.webm" type="video/webm">
@@ -105,7 +105,7 @@
         </video>
 
         <!-- Overlay Content -->
-        <div class="overlay">
+        <div class="hero-content">
             <div class="hero-overlay">
                 <h1 id="cover-title" class="main-title" data-aos="fade-up">Michael Kuell</h1>
                 <h2 class="sub-title" data-aos="fade-up" data-aos-delay="200">

--- a/styles.css
+++ b/styles.css
@@ -415,9 +415,25 @@ body.nav-open {
     background-size: cover;
 }
 
-.overlay {
-    padding: 0 2rem;
+.hero {
+    position: relative;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1;
+}
+
+.hero-content {
+    position: relative;
     z-index: 2;
+    padding: 0 2rem;
 }
 
 .hero-overlay {


### PR DESCRIPTION
## Summary
- add `.hero` dark overlay to contrast text
- wrap hero text in `.hero-content` and apply z-index

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:axe` *(fails: Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68769c8029108328a5dfa9d260e2ca7a