### PR TITLE
Add teaser accordion for Bio and testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,43 +205,38 @@
 <h2 id="testimonials-heading" data-aos="fade-up">Testimonials</h2>
         <div class="testimonials">
             <div class="testimonial">
-                <p class="excerpt">“I have worked with Michael and his team on several occasions, and from start to finish, the experience was always fantastic.” <button class="read-more" aria-expanded="false">Read More</button></p>
-                <div class="detail hidden">
+                <p class="teaser-excerpt">“I have worked with Michael and his team on several occasions, and from start to finish, the experience was always fantastic.” <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <p>Great creative thinking, detailed preparation, and highly professional execution, made this part of my projects run like clockwork. Michael and his team define 'service oriented' and the results have always been outstanding.</p>
                     <p class="author">— Jonas Bromberg, Psy.D., Principal Consultant @ Crossroads Health</p>
-                    <button class="read-less">Show Less</button>
                 </div>
             </div>
             <div class="testimonial">
-                <p class="excerpt">“I had the pleasure of being in several projects produced by Michael in my last role.” <button class="read-more" aria-expanded="false">Read More</button></p>
-                <div class="detail hidden">
+                <p class="teaser-excerpt">“I had the pleasure of being in several projects produced by Michael in my last role.” <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <p>Being in front of the camera can be very intimidating, especially when having little experience, but Michael always made the process easy to understand and fun. He is professional, approachable, and down to earth in a way that made anyone working with him want to be their best. From that perspective, I would highly recommend Michael in any client/customer facing roles.</p>
                     <p class="author">— Sonya Ponder, Diversity, Equity and Inclusion Talent Acquisition Manager at Princeton University</p>
-                    <button class="read-less">Show Less</button>
                 </div>
             </div>
             <div class="testimonial">
-                <p class="excerpt">“The last time I worked with Mike, we were under every kind of pressure possible: political, financial, creative, temporal and trying to shoot in English and French simultaneously.” <button class="read-more" aria-expanded="false">Read More</button></p>
-                <div class="detail hidden">
+                <p class="teaser-excerpt">“The last time I worked with Mike, we were under every kind of pressure possible: political, financial, creative, temporal and trying to shoot in English and French simultaneously.” <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <p>We wrapped half an hour early. I recommend Mike without reservation. As a director, cinematographer, collaborator and leader, he’s nigh on peerless. You might think trusting an airline pilot is a big deal, but for people in my business, choosing a director is much, much hairier. As far as I’m concerned, it’s Mike Kuell or we find a way to do it in print.</p>
                     <p class="author">— Dave Greeley, Partner @ McKenna and Partners</p>
-                    <button class="read-less">Show Less</button>
                 </div>
             </div>
             <div class="testimonial">
-                <p class="excerpt">“Michael is an exceptional Executive Producer, Director and Filmmaker.” <button class="read-more" aria-expanded="false">Read More</button></p>
-                <div class="detail hidden">
+                <p class="teaser-excerpt">“Michael is an exceptional Executive Producer, Director and Filmmaker.” <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <p>His level of professionalism and focus is remarkable. As a mentor, Michael has helped me redirect my skill set towards all aspects of video production. His innate ability to communicate effectively is one of his many great strengths. During a rigorous shoot that spanned 5 cities, I was privileged to witness Michael conduct over 40 interviews with some of the nation's top psychologists.</p>
                     <p class="author">— Cathleen Carr, Creative Social Impact Leader</p>
-                    <button class="read-less">Show Less</button>
                 </div>
             </div>
             <div class="testimonial">
-                <p class="excerpt">“Mike is one of the most versatile, professional, and driven filmmakers I've ever worked with.” <button class="read-more" aria-expanded="false">Read More</button></p>
-                <div class="detail hidden">
+                <p class="teaser-excerpt">“Mike is one of the most versatile, professional, and driven filmmakers I've ever worked with.” <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <p>I've seen him do great jobs with both scripted and improv comedy, drama, and commercials as well as straight-ahead corporate. He makes the most of the actors and craftspeople he works with (and has introduced me to some excellent ones), and delivers more than expected for the budget. Even more impressive: when not working for clients, he creates interesting projects on his own. That's love.</p>
                     <p class="author">— Jay Rose, Sound Designer, Digital Playroom</p>
-                    <button class="read-less">Show Less</button>
                 </div>
             </div>
         </div>
@@ -259,35 +254,31 @@
             <!-- About Me Card -->
             <div class="bio-card" data-aos="fade-up">
                 <h2>About Me</h2>
-                <p class="bio-summary">I believe a great project starts with clear goals and thoughtful planning but evolves with the flexibility to adapt and solve challenges along the way.</p>
-                <div class="bio-content" hidden>
-                    <p>I believe a great project starts with clear <strong>goals</strong> and thoughtful <strong>planning</strong> but evolves with the <strong>flexibility</strong> to adapt and solve challenges along the way. Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong> I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch.</p>
+                <p class="teaser-excerpt">I believe a great project starts with clear goals and thoughtful planning but evolves with the flexibility to adapt and solve challenges along the way. <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
+                    <p>Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results on <strong>time and within budget.</strong> I’m known for my ability to foster <strong>diverse, high-performing teams,</strong> carry a positive <strong>culture,</strong> and always keep an eye on downstream risks and <strong>opportunities.</strong> Whether it’s building a narrative from scratch or fine-tuning a big idea, I bring <strong>energy, focus, and creativity</strong> to every project I touch.</p>
                 </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>
             <!-- Experience Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="200">
                 <h2>Experience</h2>
-                <p class="bio-summary">I am a Multimedia Producer and Director with a knack for turning complex ideas into engaging content that connects with audiences and elevates brand messaging.</p>
-                <div class="bio-content" hidden>
-                    <p>I am a <strong>Multimedia Producer and Director</strong> with a knack for turning complex ideas into engaging content that connects with audiences and elevates <strong>brand messaging</strong>. My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong> I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>. </p>
+                <p class="teaser-excerpt">I am a Multimedia Producer and Director with a knack for turning complex ideas into engaging content that connects with audiences and elevates brand messaging. <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
+                    <p>My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong> I have worked across <strong>healthcare, finance, tech,</strong> and more, managing everything from <strong>live-action documentaries</strong> to <strong>corporate campaigns</strong>. I have mastered the art of balancing big-picture <strong>strategy</strong> with the nitty-gritty details to keep projects on track and teams <strong>energized</strong>. </p>
                 </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>
             <!-- Skills Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="300">
                 <h2>Skills</h2>
-                <p class="bio-summary"><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</p>
-                <div class="bio-content" hidden>
+                <p class="teaser-excerpt"><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production. <button class="teaser-toggle" aria-expanded="false">Read More</button></p>
+                <div class="teaser-full hidden">
                     <ul>
-                        <li><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.</li>
                         <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
                         <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
                         <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>
                         <li><strong>Global Storytelling:</strong> Expertise in culturally adaptive content creation for diverse audiences.</li>
                     </ul>
                 </div>
-                <button class="bio-toggle" aria-expanded="false">Read More</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -26,19 +26,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initVideoPlaceholders();
 
-  document.querySelectorAll(".testimonial").forEach(testimonial => {
-    const readMore = testimonial.querySelector(".read-more");
-    const readLess = testimonial.querySelector(".read-less");
-    const detail = testimonial.querySelector(".detail");
-    if (!readMore || !readLess || !detail) return;
-    readMore.addEventListener("click", () => {
-      detail.classList.toggle("hidden");
-      const expanded = !detail.classList.contains("hidden");
-      readMore.setAttribute("aria-expanded", expanded);
-    });
-    readLess.addEventListener("click", () => {
-      detail.classList.add("hidden");
-      readMore.setAttribute("aria-expanded", "false");
+  document.querySelectorAll(".teaser-toggle").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const section = btn.closest("section, .testimonial, .bio-card");
+      const full = section.querySelector(".teaser-full");
+      const expanded = btn.getAttribute("aria-expanded") === "true";
+      full.classList.toggle("hidden");
+      btn.textContent = expanded ? "Read More" : "Show Less";
+      btn.setAttribute("aria-expanded", String(!expanded));
     });
   });
 
@@ -84,18 +79,6 @@ if (navToggle && navList) {
   });
 }
 
-document.querySelectorAll(".bio-toggle").forEach(toggle => {
-  const bioCard = toggle.closest(".bio-card");
-  const summary = bioCard.querySelector(".bio-summary");
-  const content = bioCard.querySelector(".bio-content");
-  toggle.addEventListener("click", () => {
-    const expanded = bioCard.classList.toggle("expanded");
-    toggle.setAttribute("aria-expanded", expanded);
-    toggle.textContent = expanded ? "Show Less" : "Read More";
-    if (summary) summary.hidden = expanded;
-    if (content) content.hidden = !expanded;
-  });
-});
 
 if (navLinks.length > 0) {
   const sections = Array.from(navLinks).map(link => document.querySelector(link.hash)).filter(Boolean);

--- a/styles.css
+++ b/styles.css
@@ -540,6 +540,30 @@ body.nav-open {
     display: none;
 }
 
+.teaser-excerpt {
+    font-size: 1.125rem;
+    line-height: 1.6;
+    margin-bottom: 0.5rem;
+}
+
+.teaser-toggle {
+    background: none;
+    border: none;
+    color: #0055FF;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0;
+}
+
+.teaser-toggle:focus {
+    outline: 2px dashed #0055FF;
+    outline-offset: 2px;
+}
+
+.teaser-full {
+    margin-top: 0.75rem;
+}
+
 .accordion {
     max-width: 1200px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- implement teaser markup for testimonials and Bio cards
- add teaser styles and accessibility-focused button styling
- support expanding/collapsing with a single JS toggle handler

## Testing
- `npm run lint`
- `npm test`
- `npm run test:axe` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6877ca4e27c883288294997cda1068ff