### PR TITLE
Update accessibility workflow to use Node.js 20

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '20.x'
       - run: npm ci
       - run: npx http-server -p 8080 &
       - run: npm run audit


### PR DESCRIPTION
### Motivation
- Align the repository's accessibility audit workflow with Node.js 20 to use a current LTS runtime for CI.

### Description
- Updated `.github/workflows/accessibility.yml` to set `actions/setup-node@v3` to `node-version: '20.x'` and committed the change with message `Update workflow to use Node 20`.

### Testing
- Ran `npm install` in the repository which completed successfully and did not change `package-lock.json`; an attempted `git push` failed due to no configured remote in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1204504883289fd49d659fceca10)