### PR TITLE
Fix BIO section card spacing and heading styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -885,6 +885,10 @@ body.nav-open {
     overflow: hidden;
 }
 
+.bio-section > div {
+    width: min(1200px, 100%);
+}
+
 .bio-section::before {
     content: '';
     position: absolute;
@@ -904,6 +908,7 @@ body.nav-open {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: calc(var(--space-unit) * 2);
     max-width: 1200px;
+    width: 100%;
     margin: 0 auto;
     padding: 2rem;
 }
@@ -917,7 +922,7 @@ body.nav-open {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.bio-card h2 {
+.bio-card h3 {
     font-size: 1.8rem;
     margin-bottom: 0.8rem;
     color: var(--color-text);
@@ -979,7 +984,7 @@ body.nav-open {
     .bio-card {
         padding: 1.5rem;
     }
-    .bio-card h2 {
+    .bio-card h3 {
         font-size: 1.4rem;
     }
     .bio-card p, .bio-card ul {


### PR DESCRIPTION
### Motivation
- The BIO section cards were visually collapsing and headings were not receiving styles because the container sizing and heading selectors did not match the DOM structure.
- The intent is to allow the three cards (About Me, Experience, Skills) to lay out with correct spacing across viewports and ensure heading styles apply.

### Description
- Constrained the immediate BIO wrapper with `width: min(1200px, 100%)` to let the centered flex container and inner grid expand correctly in available space by updating `styles.css`.
- Ensured the card grid can use the full available width by adding `width: 100%` to the `.bio-cards` rule in `styles.css`.
- Corrected the heading selectors from `.bio-card h2` to `.bio-card h3` (including the mobile media query) in `styles.css` so title styling matches the HTML markup.

### Testing
- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee53f458c08328b2870957d6d1cfed)