### PR TITLE
Add expandable 'Read More' toggles to Bio section and adjust bio styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,25 +404,34 @@
             <!-- About Me Card -->
             <div class="bio-card" data-aos="fade-up">
                 <h3>About Me</h3>
-                <p class="teaser-excerpt">I believe a great project starts with clear goals and thoughtful planning but evolves with the flexibility to adapt and solve challenges along the way. <[...]
+                <p class="teaser-excerpt">
+                    I believe a great project starts with clear goals and thoughtful planning, then evolves with the flexibility to adapt and solve challenges along the way.
+                    <button class="teaser-toggle" type="button" aria-expanded="false" aria-controls="bio-about-detail">Read More</button>
+                </p>
                 <div class="teaser-full hidden">
-                    <p>Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration,</strong> staying organized, and delivering exceptional results o[...]
+                    <p id="bio-about-detail">Whether leading cross-functional teams or managing high-stakes projects, I thrive on <strong>collaboration</strong>, staying organized, and delivering exceptional results on time.</p>
                 </div>
             </div>
             <!-- Experience Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="200">
                 <h3>Experience</h3>
-                <p class="teaser-excerpt">I am a Multimedia Producer and Director with a knack for turning complex ideas into engaging content that connects with audiences and elevates brand mess[...]
+                <p class="teaser-excerpt">
+                    I am a Multimedia Producer and Director with a knack for turning complex ideas into engaging content that connects with audiences and elevates brand messaging.
+                    <button class="teaser-toggle" type="button" aria-expanded="false" aria-controls="bio-experience-detail">Read More</button>
+                </p>
                 <div class="teaser-full hidden">
-                    <p>My experience spans everything from <strong>live-streams</strong> to <strong>studio and location shoots.</strong> I have worked across <strong>healthcare, finance, tech,</s[...]
+                    <p id="bio-experience-detail">My experience spans <strong>live-streams</strong>, <strong>studio shoots</strong>, and <strong>location production</strong> across healthcare, finance, technology, and nonprofit organizations.</p>
                 </div>
             </div>
             <!-- Skills Card -->
             <div class="bio-card" data-aos="fade-up" data-aos-delay="300">
                 <h3>Skills</h3>
-                <p class="teaser-excerpt"><strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production. <button class="teaser-togg[...]
+                <p class="teaser-excerpt">
+                    <strong>Video Production &amp; Post-Production:</strong> Adobe Premiere Pro, After Effects, studio and on-location production.
+                    <button class="teaser-toggle" type="button" aria-expanded="false" aria-controls="bio-skills-detail">Read More</button>
+                </p>
                 <div class="teaser-full hidden">
-                    <ul>
+                    <ul id="bio-skills-detail">
                         <li><strong>Digital Strategy:</strong> Metadata creation, SEO, and analytics-driven refinements.</li>
                         <li><strong>Directing Talent:</strong> Prepping, coaching and directing talent, from actors to C-suite executives.</li>
                         <li><strong>Collaborative Leadership:</strong> Team scaling, talent coaching, vendor oversight.</li>

--- a/styles.css
+++ b/styles.css
@@ -885,6 +885,10 @@ body.nav-open {
     overflow: hidden;
 }
 
+.bio-section > div {
+    width: min(1200px, 100%);
+}
+
 .bio-section::before {
     content: '';
     position: absolute;
@@ -904,6 +908,7 @@ body.nav-open {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: calc(var(--space-unit) * 2);
     max-width: 1200px;
+    width: 100%;
     margin: 0 auto;
     padding: 2rem;
 }
@@ -917,7 +922,7 @@ body.nav-open {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.bio-card h2 {
+.bio-card h3 {
     font-size: 1.8rem;
     margin-bottom: 0.8rem;
     color: var(--color-text);
@@ -979,7 +984,7 @@ body.nav-open {
     .bio-card {
         padding: 1.5rem;
     }
-    .bio-card h2 {
+    .bio-card h3 {
         font-size: 1.4rem;
     }
     .bio-card p, .bio-card ul {


### PR DESCRIPTION
### Motivation
- Improve the Bio section's readability and accessibility by exposing short teasers with optional expandable details via explicit "Read More" controls.
- Align CSS selectors with the markup and ensure the bio layout scales cleanly across screen sizes.

### Description
- Inserted inline `Read More` buttons into each bio teaser with `aria-expanded="false"` and `aria-controls` attributes and moved full content into hidden detail elements with unique IDs (`bio-about-detail`, `bio-experience-detail`, `bio-skills-detail`).
- Updated styles by adding a wrapper width rule `.bio-section > div { width: min(1200px, 100%); }`, setting `.bio-cards { width: 100%; }`, and converting the heading selector from `.bio-card h2` to `.bio-card h3` to match the HTML.
- Ensured skill list is targetable via `id="bio-skills-detail"` and kept the expanded/collapsed patterns consistent with existing `.teaser-full.hidden` markup.

### Testing
- Ran the project's linter with `npm run lint` and it completed successfully.
- Built the site with `npm run build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee53f458c08328b2870957d6d1cfed)