### PR TITLE
perf: ship minified assets and automate build on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Minified Assets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'styles.css'
+      - 'script.js'
+      - 'index.html'
+      - '404.html'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build minified CSS and JS
+        run: npm run build
+
+      - name: Commit minified assets if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add styles.min.css script.min.js
+          git diff --cached --quiet || git commit -m "build: regenerate minified assets"
+          git push

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
 
     <!-- External CSS -->
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.min.css">
 
     <!-- Structured Data for SEO -->
     <script type="application/ld+json">
@@ -443,7 +443,7 @@
 </footer>
 
 <!-- External JavaScript -->
-<script src="script.js"></script>
+<script src="script.min.js"></script>
 <!-- AOS JS (self-hosted) -->
 <script src="assets/vendor/aos/aos.js" defer></script>
 <script defer>


### PR DESCRIPTION
- index.html now references styles.min.css and script.min.js (~22 KB savings)
- adds .github/workflows/build.yml to regenerate minified assets automatically
  whenever styles.css, script.js, index.html, or 404.html change on main

https://claude.ai/code/session_01USEMfbd2FFzkGqjYSqRLeF