### PR TITLE
Reorder work: move Orvis Spec Ad between Bear Spot Farm and Crafting

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,15 +162,6 @@
             </div>
         </div>
                 <div class="work-card">
-            <div class="video-wrapper" data-src="https://www.youtube-nocookie.com/embed/fYFGi8RpYJ0" data-title="Orvis Spec Ad :Abby">
-                <img src="https://img.youtube.com/vi/fYFGi8RpYJ0/hqdefault.jpg" alt="Thumbnail for Orvis Spec Ad :Abby" loading="lazy">
-                <button class="play-button" aria-label="Play Orvis Spec Ad :Abby" type="button">▶</button>
-          </div>
-            <div class="work-card__caption">
-                <h3 class="work-card__title">Orvis Spec Ad :Abby</h3>
-            </div>
-        </div>
-                <div class="work-card">
             <div class="video-wrapper" data-src="https://www.youtube-nocookie.com/embed/ABl3Gv-LD64" data-title="Interviews : Capturing Authentic Expertise">
                 <img src="https://img.youtube.com/vi/ABl3Gv-LD64/hqdefault.jpg" alt="Thumbnail for Interviews : Capturing Authentic Expertise" loading="lazy">
                 <button class="play-button" aria-label="Play Interviews : Capturing Authentic Expertise" type="button">▶</button>
@@ -213,6 +204,15 @@
             </div>
             <div class="work-card__caption">
                 <h3 class="work-card__title">Bear Spot Farm Project</h3>
+            </div>
+        </div>
+                <div class="work-card">
+            <div class="video-wrapper" data-src="https://www.youtube-nocookie.com/embed/fYFGi8RpYJ0" data-title="Orvis Spec Ad :Abby">
+                <img src="https://img.youtube.com/vi/fYFGi8RpYJ0/hqdefault.jpg" alt="Thumbnail for Orvis Spec Ad :Abby" loading="lazy">
+                <button class="play-button" aria-label="Play Orvis Spec Ad :Abby" type="button">▶</button>
+          </div>
+            <div class="work-card__caption">
+                <h3 class="work-card__title">Orvis Spec Ad :Abby</h3>
             </div>
         </div>
         <div class="work-card">


### PR DESCRIPTION
Places the Orvis Spec Ad :Abby card between Bear Spot Farm and the Crafting - Time Is An Asset Campaign card so the two Time Is An Asset Campaign pieces no longer bracket the rest of the reel.