### PR TITLE
ci: bump checkout and setup-node actions to v4

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -5,8 +5,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
       - run: npm ci

--- a/.github/workflows/video-sitemap.yml
+++ b/.github/workflows/video-sitemap.yml
@@ -13,14 +13,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Show Git diagnostics
         run: |
           git status
           git remote -v
           git branch
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` from `@v3` to `@v4` in `accessibility.yml` and `video-sitemap.yml`
- Silences the GitHub Actions Node.js 20 deprecation warning
- Matches the versions already used by `build.yml` for consistency across workflows

## Notes
- `video-sitemap.yml` still pins `node-version: 16` for the runtime — that's a separate concern from the action versions and not addressed here.
- No functional change to any workflow logic.

## Test plan
- [ ] CI runs on this PR without the Node 20 deprecation warning
- [ ] `audit` job behavior unchanged (passes or fails for the same reasons as before)

https://claude.ai/code/session_01MhyeMUxsgFWYQxzCwVrKWg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhyeMUxsgFWYQxzCwVrKWg)_