### PR TITLE
Fix Accessibility Audit CI Chrome/ChromeDriver mismatch

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -10,5 +10,6 @@ jobs:
         with:
           node-version: '20.x'
       - run: npm ci
+      - run: npx browser-driver-manager install chrome
       - run: npx http-server -p 8080 &
       - run: npm run audit


### PR DESCRIPTION
## Summary
- The `Accessibility Audit` workflow has been failing on every PR since at least May 2026, unrelated to the changes under review
- Root cause: the runner's preinstalled Chrome (149.x) and axe-core's auto-installed ChromeDriver (150.x) are on mismatched versions, so `npx @axe-core/cli` fails with `session not created: This version of ChromeDriver only supports Chrome version 150`
- Added a `npx browser-driver-manager install chrome` step before running the audit, which installs a synced Chrome + ChromeDriver pair

## Test plan
- [ ] Confirm the `Accessibility Audit` check passes on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_012kvwQWqgh7x6JjwvsXmf5Q)_