### PR TITLE
Include YouTube-embedded videos in video sitemap

### DIFF
--- a/scripts/generateVideoSitemap.js
+++ b/scripts/generateVideoSitemap.js
@@ -25,7 +25,9 @@ function extractFromFile(filePath, baseUrl) {
   const dom = new JSDOM(html);
   const document = dom.window.document;
 
-  const wrappers = Array.from(document.querySelectorAll('[data-src^="https://player.vimeo.com/video/"]'));
+  const wrappers = Array.from(document.querySelectorAll(
+    '[data-src^="https://player.vimeo.com/video/"], [data-src^="https://www.youtube-nocookie.com/embed/"], [data-src^="https://www.youtube.com/embed/"]'
+  ));
   return wrappers.map(wrapper => {
     const playerUrl = wrapper.getAttribute('data-src');
     const img = wrapper.querySelector('img');

--- a/video-sitemap.xml
+++ b/video-sitemap.xml
@@ -4,6 +4,22 @@
   <url>
     <loc>https://michaelkuell.com/</loc>
     <video:video>
+      <video:player_loc>https://www.youtube-nocookie.com/embed/zZLAUAPX044</video:player_loc>
+      <video:thumbnail_loc>https://img.youtube.com/vi/zZLAUAPX044/hqdefault.jpg</video:thumbnail_loc>
+      <video:title>AI Sizzle Reel</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://www.youtube-nocookie.com/embed/ABl3Gv-LD64</video:player_loc>
+      <video:thumbnail_loc>https://img.youtube.com/vi/ABl3Gv-LD64/hqdefault.jpg</video:thumbnail_loc>
+      <video:title>Interviews : Capturing Authentic Expertise</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
       <video:player_loc>https://player.vimeo.com/video/1078827186</video:player_loc>
       <video:thumbnail_loc>https://vumbnail.com/1078827186.jpg</video:thumbnail_loc>
       <video:title>A Ronin Story</video:title>
@@ -31,6 +47,14 @@
       <video:player_loc>https://player.vimeo.com/video/231089330</video:player_loc>
       <video:thumbnail_loc>https://vumbnail.com/231089330.jpg</video:thumbnail_loc>
       <video:title>Bear Spot Farm Project</video:title>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://michaelkuell.com/</loc>
+    <video:video>
+      <video:player_loc>https://www.youtube-nocookie.com/embed/fYFGi8RpYJ0</video:player_loc>
+      <video:thumbnail_loc>https://img.youtube.com/vi/fYFGi8RpYJ0/hqdefault.jpg</video:thumbnail_loc>
+      <video:title>Orvis Spec Ad :Abby</video:title>
     </video:video>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- `scripts/generateVideoSitemap.js` only matched elements with `data-src^="https://player.vimeo.com/video/"`, so the 3 YouTube-embedded videos on the homepage ("AI Sizzle Reel", "Interviews : Capturing Authentic Expertise", "Orvis Spec Ad :Abby") were silently excluded from `video-sitemap.xml`.
- Broadened the selector to also match `youtube.com/embed/` and `youtube-nocookie.com/embed/` wrappers, so all 12 videos on the page are now included.
- Regenerated `video-sitemap.xml` (now 12 `<url>` entries instead of 9), using each video's existing `img.youtube.com/vi/<id>/hqdefault.jpg` thumbnail and `youtube-nocookie.com/embed/<id>` player URL.

## Test plan
- [x] Ran `node scripts/generateVideoSitemap.js` locally and confirmed the output contains all 12 videos in page order with correct player/thumbnail URLs
- [x] Ran `npx eslint scripts/generateVideoSitemap.js` — no issues


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3eLXxQzLzTgYWEZMFRJdT)_